### PR TITLE
Remove `webdrivers` from gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,5 +43,4 @@ group :test do
   gem 'selenium-webdriver'
   gem 'simplecov', require: false
   gem 'simplecov-cobertura'
-  gem 'webdrivers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,10 +297,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.3.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
     websocket (1.2.9)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -340,7 +336,6 @@ DEPENDENCIES
   view_component
   vite_rails
   web-console
-  webdrivers
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/gemset.nix
+++ b/gemset.nix
@@ -1134,17 +1134,6 @@
     };
     version = "4.2.0";
   };
-  webdrivers = {
-    dependencies = ["nokogiri" "rubyzip" "selenium-webdriver"];
-    groups = ["test"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "19aaxhawzv7315rh285gd1fg6m6wbrn3w3kilyibci1wphgm7mfp";
-      type = "gem";
-    };
-    version = "5.3.1";
-  };
   websocket = {
     groups = ["default" "test"];
     platforms = [];


### PR DESCRIPTION
This fixes the infinite loop between updates of webdrivers and selenium-webdriver