### PR TITLE
Use `Nokogiri::HTML5.parse` so that breaks don't have children

### DIFF
--- a/app/components/entry_component.rb
+++ b/app/components/entry_component.rb
@@ -15,12 +15,12 @@ class EntryComponent < ViewComponent::Base
   def transformed_summary
     return if entry.summary.blank?
 
-    doc = Nokogiri.parse(entry.summary)
+    doc = Nokogiri::HTML5.parse(entry.summary)
     replace_images(doc).to_html.strip
   end
 
   def transformed_body
-    doc = Nokogiri.parse(entry.body)
+    doc = Nokogiri::HTML5.parse(entry.body)
     replace_images(doc).to_html.strip
   end
 

--- a/app/jobs/detect_entry_images_job.rb
+++ b/app/jobs/detect_entry_images_job.rb
@@ -11,7 +11,7 @@ class DetectEntryImagesJob < ApplicationJob
   private
 
   def process(entry, method)
-    doc = Nokogiri.parse(entry.send(method))
+    doc = Nokogiri::HTML5.parse(entry.send(method))
     doc.css('img').each do |node|
       next if TrackingDetection.tracking_pixel?(node) || !node.key?('src')
 

--- a/test/components/entry_component_test.rb
+++ b/test/components/entry_component_test.rb
@@ -20,7 +20,7 @@ class EntryComponentTest < ViewComponent::TestCase
     render_inline(EntryComponent.new(entry:))
 
     assert_selector '.entry__body'
-    assert_equal '<div></div>', page.find('.entry__body')[:srcdoc]
+    assert_equal '<html><head></head><body><div></div></body></html>', page.find('.entry__body')[:srcdoc]
   end
 
   test 'should remove tracking pixels when rendering summary' do
@@ -40,7 +40,8 @@ class EntryComponentTest < ViewComponent::TestCase
     render_inline(EntryComponent.new(entry:))
 
     assert_selector '.entry__body'
-    assert_equal body, page.find('.entry__body')[:srcdoc]
+    assert_equal '<html><head></head><body><div><img src="https://example.com/image.jpg"></div></body></html>',
+                 page.find('.entry__body')[:srcdoc]
   end
 
   test 'should reaplce image src when proxied' do


### PR DESCRIPTION
When using `Nokogiri.parse` an unclosed break tag `<br>` will have it's sibling elements as children.