### PR TITLE
Don't use turbo for navigation to good job dashboard

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
           <%= link_to t('.subscriptions'), subscriptions_path %>
           <%= link_to t('.sign_out'), destroy_session_path, data: { turbo_method: :delete } %>
           <%- if current_user.admin? %>
-            <%= link_to t('.good_job'), good_job_path %>
+            <%= link_to t('.good_job'), good_job_path, data: { turbo: false } %>
           <% end %>
         <%- end %>
       </nav>


### PR DESCRIPTION
With turbo the stylesheets from the dashboard might stick when navigating back to the main application.