### PR TITLE
Allow user to group subscriptions in categories

### DIFF
--- a/app/components/forms/base_component.rb
+++ b/app/components/forms/base_component.rb
@@ -1,17 +1,18 @@
 # frozen_string_literal: true
 
 class Forms::BaseComponent < ViewComponent::Base
-  attr_reader :form, :name, :hint, :disabled
+  attr_reader :form, :name, :hint, :disabled, :options
 
   # rubocop:disable Metrics/ParameterLists
   # We need to have a lot of parameters here, since this is a very generic component
-  def initialize(form:, name:, hint: nil, error: nil, disabled: false, **html_attrs)
+  def initialize(form:, name:, hint: nil, error: nil, disabled: false, options: [], **html_attrs)
     super
     @form = form
     @name = name
     @hint = hint
     @error = error
     @disabled = disabled
+    @options = options.map { |opt| Array.wrap(opt) }
     @class = html_attrs.delete(:class).presence || ''
     @html_attrs = html_attrs
   end
@@ -27,5 +28,9 @@ class Forms::BaseComponent < ViewComponent::Base
 
   def invalid?
     error.present?
+  end
+
+  def element_id(type)
+    [form.object_name, name, type].join('_')
   end
 end

--- a/app/components/forms/email_input_component.html.erb
+++ b/app/components/forms/email_input_component.html.erb
@@ -1,6 +1,13 @@
 <%= content_tag :div, class: ['input', 'input--email', { 'input--valid': valid? }, { 'input--invalid': invalid? }, @class], **@html_attrs do %>
   <%= form.label name, class: 'input__label' %>
-  <%= form.email_field name, class: 'input__field', disabled: %>
+  <%= form.email_field name, class: 'input__field', disabled:, list: element_id(:datalist) %>
+  <%- if options.present? %>
+    <%= content_tag :datalist, id: element_id(:datalist) do %>
+      <%- options.each do |opt| %>
+        <%= content_tag :option, opt[1].presence || opt[0], value: opt[0] %>
+      <%- end %>
+    <% end %>
+  <%- end %>
   <%- if hint.present? %>
     <%= content_tag :span, hint, class: 'input__hint' %>
   <%- end %>

--- a/app/components/forms/password_input_component.rb
+++ b/app/components/forms/password_input_component.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
 class Forms::PasswordInputComponent < Forms::BaseComponent
+  def initialize(**)
+    super(**)
+    raise 'Options is not supported for password inputs' if options.present?
+  end
 end

--- a/app/components/forms/password_input_component.rb
+++ b/app/components/forms/password_input_component.rb
@@ -3,6 +3,6 @@
 class Forms::PasswordInputComponent < Forms::BaseComponent
   def initialize(**)
     super(**)
-    raise 'Options is not supported for password inputs' if options.present?
+    raise ArgumentError, 'Options is not supported for password inputs' if options.present?
   end
 end

--- a/app/components/forms/radio_input_component.html.erb
+++ b/app/components/forms/radio_input_component.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag :div, class: ['radio-buttons', { 'radio-buttons--valid': valid? }, { 'radio-buttons--invalid': invalid? }, @class], **@html_attrs do %>
   <%= form.label name, class: 'radio-buttons__label' %>
-  <%= form.collection_radio_buttons name, collection, :first, :second, { disabled:, include_hidden: false } do |rb| %>
+  <%= form.collection_radio_buttons name, options, :first, :second, { disabled:, include_hidden: false } do |rb| %>
     <%= rb.radio_button class: 'radio-buttons__option-field', disabled: %>
     <%= rb.label class: 'radio-buttons__option-label' %>
   <% end %>

--- a/app/components/forms/radio_input_component.rb
+++ b/app/components/forms/radio_input_component.rb
@@ -1,10 +1,4 @@
 # frozen_string_literal: true
 
 class Forms::RadioInputComponent < Forms::BaseComponent
-  attr_reader :collection
-
-  def initialize(**args)
-    @collection = args.delete(:collection)
-    super(**args)
-  end
 end

--- a/app/components/forms/text_input_component.html.erb
+++ b/app/components/forms/text_input_component.html.erb
@@ -1,6 +1,13 @@
 <%= content_tag :div, class: ['input', 'input--text', { 'input--valid': valid? }, { 'input--invalid': invalid? }, @class], **@html_attrs do %>
   <%= form.label name, class: 'input__label' %>
-  <%= form.text_field name, class: 'input__field', disabled: %>
+  <%= form.text_field name, class: 'input__field', disabled:, list: element_id(:datalist) %>
+  <%- if options.present? %>
+    <%= content_tag :datalist, id: element_id(:datalist) do %>
+      <%- options.each do |opt| %>
+        <%= content_tag :option, opt[1].presence || opt[0], value: opt[0] %>
+      <%- end %>
+    <% end %>
+  <%- end %>
   <%- if hint.present? %>
     <%= content_tag :span, hint, class: 'input__hint' %>
   <%- end %>

--- a/app/components/forms/url_input_component.html.erb
+++ b/app/components/forms/url_input_component.html.erb
@@ -1,6 +1,13 @@
 <%= content_tag :div, class: ['input', 'input--url', { 'input--valid': valid? }, { 'input--invalid': invalid? }, @class], **@html_attrs do %>
   <%= form.label name, class: 'input__label' %>
-  <%= form.url_field name, class: 'input__field', disabled: %>
+  <%= form.url_field name, class: 'input__field', disabled:, list: element_id(:datalist) %>
+    <%- if options.present? %>
+    <%= content_tag :datalist, id: element_id(:datalist) do %>
+      <%- options.each do |opt| %>
+        <%= content_tag :option, opt[1].presence || opt[0], value: opt[0] %>
+      <%- end %>
+    <% end %>
+  <%- end %>
   <%- if hint.present? %>
     <%= content_tag :span, hint, class: 'input__hint' %>
   <%- end %>

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Category < ApplicationRecord
+  belongs_to :parent, class_name: 'Category', optional: true, inverse_of: :children
+  has_many :children, class_name: 'Category', foreign_key: :parent_id, dependent: :destroy, inverse_of: :parent
+  has_many :subscriptions, dependent: :restrict_with_error
+
+  validates :name, presence: true, uniqueness: { scope: :parent }
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -31,6 +31,14 @@ class Subscription < ApplicationRecord
     end
   end
 
+  def self.category_text_options
+    where.not(category_text: nil).pluck(:category_text).map do |text|
+      text.split('>').each_with_object([]) do |part, arr|
+        arr.push [arr.last, part.strip].compact.join(' > ')
+      end
+    end.flatten.uniq.sort
+  end
+
   private
 
   def create_categories_from_text

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -8,7 +8,7 @@ class Subscription < ApplicationRecord
 
   accepts_nested_attributes_for :subscribable
 
-  normalizes :category_text, with: ->(text) { text&.split('>')&.map(&:strip)&.join(' > ') }
+  normalizes :category_text, with: ->(text) { text.split('>').map(&:strip).join(' > ') if text.present? }
 
   validates :name, presence: true
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -4,10 +4,13 @@ class Subscription < ApplicationRecord
   belongs_to :user, inverse_of: :subscriptions
   has_many :entries, dependent: :destroy
   belongs_to :subscribable, polymorphic: true, inverse_of: :subscription
+  belongs_to :category, inverse_of: :subscriptions, optional: true
 
   accepts_nested_attributes_for :subscribable
 
   validates :name, presence: true
+
+  before_validation :create_categories_from_text
 
   def refreshable?
     subscribable.respond_to? :refresh!
@@ -24,5 +27,17 @@ class Subscription < ApplicationRecord
     params.each_pair do |key, value|
       subscribable.send(:"#{key}=", value) if subscribable.has_attribute? key
     end
+  end
+
+  private
+
+  def create_categories_from_text
+    return unless category_text_changed? && category_text.present?
+
+    current = nil
+    category_text.split('>').map(&:strip).each do |name|
+      current = Category.find_or_create_by(name:, parent: current)
+    end
+    self.category = current
   end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -8,6 +8,8 @@ class Subscription < ApplicationRecord
 
   accepts_nested_attributes_for :subscribable
 
+  normalizes :category_text, with: ->(text) { text&.split('>')&.map(&:strip)&.join(' > ') }
+
   validates :name, presence: true
 
   before_validation :create_categories_from_text

--- a/app/policies/subscription_policy.rb
+++ b/app/policies/subscription_policy.rb
@@ -28,7 +28,7 @@ class SubscriptionPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    own = %i[name subscribable_type]
+    own = %i[name subscribable_type category_text]
     own + [subscribable_attributes: %i[url]]
   end
 end

--- a/app/views/subscriptions/_form.html.erb
+++ b/app/views/subscriptions/_form.html.erb
@@ -3,6 +3,7 @@
 <%= form_with model: subscription, class: 'form' do |form| %>
 
   <%= form.input :name %>
+  <%= form.input :category_text, hint: t('.category_hint') %>
   <%= form.input :subscribable_type, as: :radio,
                                      collection: [['RssFeed', 'Rss Feed'], ['Newsletter', 'Newsletter']],
                                      disabled: form.object.persisted? %>

--- a/app/views/subscriptions/_form.html.erb
+++ b/app/views/subscriptions/_form.html.erb
@@ -3,7 +3,7 @@
 <%= form_with model: subscription, class: 'form' do |form| %>
 
   <%= form.input :name %>
-  <%= form.input :category_text, hint: t('.category_hint') %>
+  <%= form.input :category_text, hint: t('.category_hint'), collection: policy_scope(Subscription).category_text_options %>
   <%= form.input :subscribable_type, as: :radio,
                                      collection: [['RssFeed', 'Rss Feed'], ['Newsletter', 'Newsletter']],
                                      disabled: form.object.persisted? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,9 @@
 en:
+  activerecord:
+    attributes:
+      subscription:
+        category_text: 'Category'
+        subscribable_type: 'Type'
   application_controller:
     helpers:
       user_not_authorized:
@@ -15,6 +20,8 @@ en:
       mark_as_read: Mark as read
       mark_as_unread: Mark as unread
   subscriptions:
+    form:
+      category_hint: 'You can nest categories using `>`. For example: `Music > Bands`'
     index:
       page_title: Subscriptions
       actions: Actions

--- a/db/migrate/20231101190143_create_categories.rb
+++ b/db/migrate/20231101190143_create_categories.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateCategories < ActiveRecord::Migration[7.1]
+  def change
+    create_table :categories do |t|
+      t.string :name, null: false
+      t.references :parent, null: true, foreign_key: { to_table: :categories }
+
+      t.timestamps
+
+      t.index %i[name parent_id], unique: true
+    end
+
+    change_table :subscriptions, bulk: true do |t|
+      t.string :category_text
+      t.references :category, null: true, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_01_100919) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_01_190143) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -50,6 +50,15 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_01_100919) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name", null: false
+    t.bigint "parent_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name", "parent_id"], name: "index_categories_on_name_and_parent_id", unique: true
+    t.index ["parent_id"], name: "index_categories_on_parent_id"
   end
 
   create_table "entries", force: :cascade do |t|
@@ -176,6 +185,9 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_01_100919) do
     t.bigint "subscribable_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "category_text"
+    t.bigint "category_id"
+    t.index ["category_id"], name: "index_subscriptions_on_category_id"
     t.index ["subscribable_type", "subscribable_id"], name: "index_subscriptions_on_subscribable"
     t.index ["user_id"], name: "index_subscriptions_on_user_id"
   end
@@ -191,7 +203,9 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_01_100919) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "categories", "categories", column: "parent_id"
   add_foreign_key "entries", "subscriptions"
   add_foreign_key "proxied_images", "entries"
+  add_foreign_key "subscriptions", "categories"
   add_foreign_key "subscriptions", "users"
 end

--- a/test/components/forms/email_input_component_test.rb
+++ b/test/components/forms/email_input_component_test.rb
@@ -45,7 +45,7 @@ class Forms::EmailInputComponentTest < ViewComponent::TestCase
 
   test 'should render datalist if passed options' do
     options = ['opt1', ['opt2', 'Option 2']]
-    render_inline(Forms.user_email_datalistInputComponent.new(form: @form, name: :email, options:))
+    render_inline(Forms::EmailInputComponent.new(form: @form, name: :email, options:))
 
     assert_selector 'datalist#user_email_datalist'
     assert_selector 'datalist option[value="opt1"]', text: 'opt1'

--- a/test/components/forms/email_input_component_test.rb
+++ b/test/components/forms/email_input_component_test.rb
@@ -42,4 +42,13 @@ class Forms::EmailInputComponentTest < ViewComponent::TestCase
 
     assert_selector '.input.my-class[data-foo="bar"]'
   end
+
+  test 'should render datalist if passed options' do
+    options = ['opt1', ['opt2', 'Option 2']]
+    render_inline(Forms.user_email_datalistInputComponent.new(form: @form, name: :email, options:))
+
+    assert_selector 'datalist#user_email_datalist'
+    assert_selector 'datalist option[value="opt1"]', text: 'opt1'
+    assert_selector 'datalist option[value="opt2"]', text: 'Option 2'
+  end
 end

--- a/test/components/forms/password_input_component_test.rb
+++ b/test/components/forms/password_input_component_test.rb
@@ -43,4 +43,12 @@ class Forms::PasswordInputComponentTest < ViewComponent::TestCase
 
     assert_selector '.input.my-class[data-foo="bar"]'
   end
+
+  test 'should raise error if passed options' do
+    options = ['opt1', ['opt2', 'Option 2']]
+
+    assert_raises ArgumentError do
+      render_inline(Forms::PasswordInputComponent.new(form: @form, name: :password, options:))
+    end
+  end
 end

--- a/test/components/forms/radio_input_component_test.rb
+++ b/test/components/forms/radio_input_component_test.rb
@@ -12,7 +12,7 @@ class Forms::RadioInputComponentTest < ViewComponent::TestCase
   end
 
   test 'should render input with options' do
-    render_inline(Forms::RadioInputComponent.new(form: @form, name: :email, collection: @options))
+    render_inline(Forms::RadioInputComponent.new(form: @form, name: :email, options: @options))
 
     assert_selector '.radio-buttons'
     assert_selector '.radio-buttons__label', text: 'Email'
@@ -20,7 +20,7 @@ class Forms::RadioInputComponentTest < ViewComponent::TestCase
   end
 
   test 'should render hint and error when value is passed' do
-    render_inline(Forms::RadioInputComponent.new(form: @form, name: :email, collection: @options,
+    render_inline(Forms::RadioInputComponent.new(form: @form, name: :email, options: @options,
                                                  hint: 'foobar@example.org',
                                                  error: 'This field is required'))
 
@@ -33,13 +33,13 @@ class Forms::RadioInputComponentTest < ViewComponent::TestCase
     @object.email = nil
     @object.validate
 
-    render_inline(Forms::RadioInputComponent.new(form: @form, name: :email, collection: @options))
+    render_inline(Forms::RadioInputComponent.new(form: @form, name: :email, options: @options))
 
     assert_selector '.radio-buttons__error', text: 'Email can\'t be blank'
   end
 
   test 'should render additional html attributes' do
-    render_inline(Forms::RadioInputComponent.new(form: @form, name: :email, collection: @options,
+    render_inline(Forms::RadioInputComponent.new(form: @form, name: :email, options: @options,
                                                  class: 'my-class',
                                                  data: { foo: :bar }))
 

--- a/test/components/forms/text_input_component_test.rb
+++ b/test/components/forms/text_input_component_test.rb
@@ -42,4 +42,13 @@ class Forms::TextInputComponentTest < ViewComponent::TestCase
 
     assert_selector '.input.my-class[data-foo="bar"]'
   end
+
+  test 'should render datalist if passed options' do
+    options = ['opt1', ['opt2', 'Option 2']]
+    render_inline(Forms::TextInputComponent.new(form: @form, name: :name, options:))
+
+    assert_selector 'datalist#subscription_name_datalist'
+    assert_selector 'datalist option[value="opt1"]', text: 'opt1'
+    assert_selector 'datalist option[value="opt2"]', text: 'Option 2'
+  end
 end

--- a/test/components/forms/url_input_component_test.rb
+++ b/test/components/forms/url_input_component_test.rb
@@ -42,4 +42,13 @@ class Forms::UrlInputComponentTest < ViewComponent::TestCase
 
     assert_selector '.input.my-class[data-foo="bar"]'
   end
+
+  test 'should render datalist if passed options' do
+    options = ['opt1', ['opt2', 'Option 2']]
+    render_inline(Forms::UrlInputComponent.new(form: @form, name: :url, options:))
+
+    assert_selector 'datalist#rss_feed_url_datalist'
+    assert_selector 'datalist option[value="opt1"]', text: 'opt1'
+    assert_selector 'datalist option[value="opt2"]', text: 'Option 2'
+  end
 end

--- a/test/factories/categories.rb
+++ b/test/factories/categories.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :category do
+    name { Faker::Lorem.unique.word }
+  end
+end

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CategoryTest < ActiveSupport::TestCase
+  # Validations
+  test 'should not be valid without a name' do
+    category = build(:category, name: nil)
+
+    assert_not_predicate category, :valid?
+    assert_includes category.errors['name'], "can't be blank"
+  end
+
+  test 'should not be valid if name is not unique for parent' do
+    parent = create(:category, name: 'music')
+    create(:category, parent:, name: 'music')
+    child = build(:category, parent:, name: 'music')
+
+    assert_not_predicate child, :valid?
+    assert_includes child.errors['name'], 'has already been taken'
+  end
+
+  test 'should not save in database with a name that is not unique for parent' do
+    parent = create(:category, name: 'music')
+    create(:category, parent:, name: 'music')
+
+    assert_raises ActiveRecord::RecordNotUnique do
+      # rubocop:disable Rails/SkipsModelValidations
+      # We intentionally skip model validations to test the database constraint
+      Category.insert!(attributes_for(:category, name: 'music', parent_id: parent.id))
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+  end
+end

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -14,10 +14,14 @@ class SubscriptionTest < ActiveSupport::TestCase
   # Normalizes
   test 'should normalize categy text' do
     subscription = build(:subscription, category_text: ' Music>Bands  > Concerts')
-
     subscription.validate
 
     assert_equal 'Music > Bands > Concerts', subscription.category_text
+
+    subscription.category_text = ' '
+    subscription.validate
+
+    assert_nil subscription.category_text
   end
 
   # Callbacks

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -11,6 +11,15 @@ class SubscriptionTest < ActiveSupport::TestCase
     assert_includes subscription.errors['name'], "can't be blank"
   end
 
+  # Normalizes
+  test 'should normalize categy text' do
+    subscription = build(:subscription, category_text: ' Music>Bands  > Concerts')
+
+    subscription.validate
+
+    assert_equal 'Music > Bands > Concerts', subscription.category_text
+  end
+
   # Callbacks
   test 'should create categories based on text during validations' do
     subscription = build(:subscription, category_text: 'music > bands')

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -43,4 +43,16 @@ class SubscriptionTest < ActiveSupport::TestCase
     assert_equal 'bands', subscription.category.name
     assert_equal category, subscription.category.parent
   end
+
+  # Class methods
+  test 'should build category text options' do
+    create(:subscription, category_text: nil)
+    create(:subscription, category_text: 'Music > Bands > Concerts')
+    create(:subscription, category_text: 'Music > Venues')
+    create(:subscription, category_text: 'Art > Exhibitions')
+
+    expected = ['Art', 'Art > Exhibitions', 'Music', 'Music > Bands', 'Music > Bands > Concerts', 'Music > Venues']
+
+    assert_equal expected, Subscription.category_text_options
+  end
 end

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -10,4 +10,28 @@ class SubscriptionTest < ActiveSupport::TestCase
     assert_not_predicate subscription, :valid?
     assert_includes subscription.errors['name'], "can't be blank"
   end
+
+  # Callbacks
+  test 'should create categories based on text during validations' do
+    subscription = build(:subscription, category_text: 'music > bands')
+
+    assert_difference 'Category.count', 2 do
+      subscription.validate
+    end
+
+    assert_equal 'bands', subscription.category.name
+    assert_equal 'music', subscription.category.parent.name
+  end
+
+  test 'should re-use existing categories when creating categories' do
+    category = create(:category, name: 'music')
+    subscription = build(:subscription, category_text: 'music > bands')
+
+    assert_difference 'Category.count', 1 do
+      subscription.validate
+    end
+
+    assert_equal 'bands', subscription.category.name
+    assert_equal category, subscription.category.parent
+  end
 end


### PR DESCRIPTION
Fix #93 

This PR allows a user to specify a `category_text`. This text can be a single category, or an infinite chain of categories `Music > Concerts > Bands`.