### PR TITLE
Handle case where `mail.received` is a field

### DIFF
--- a/app/mailboxes/newsletter_mailbox.rb
+++ b/app/mailboxes/newsletter_mailbox.rb
@@ -42,7 +42,9 @@ class NewsletterMailbox < ApplicationMailbox
   def recipients
     arr = [*mail.recipients]
     # Look in the received header, since some forwards don't modify recipients
-    received = mail.received&.first&.decoded&.match(/<([a-z@\d\.\-\+]+)>/i)
+    # If this is the case, we should only care about the final received item
+    # NOTE: `mail.received` can be an instance of `Mail::ReceivedField` or an array of instances
+    received = Array.wrap(mail.received).first&.decoded&.match(/<([a-z@\d\.\-\+]+)>/i)
     arr.push(received[1]) if received.present?
     arr
   end


### PR DESCRIPTION
`mail.received` can return either an array of fields or a field directly, so we wrap it in `Array.wrap`.

Fix #107 