### PR TITLE
Create filters for entries overview

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'pagy' # Use pagy for pagination
 gem 'pg' # Use postgresql as the database for Active Record
 gem 'puma' # Use the Puma web server [https://github.com/puma/puma]
 gem 'pundit' # Use pundit for easy authorization
+gem 'ransack' # Use ransack for searching and sorting
 gem 'turbo-rails' # Use Turbo for progressive enhancement of requests
 gem 'view_component' # Use ViewComponent to replace partials
 gem 'vite_rails' # Use ViteRails to compile assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,6 +256,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.0.6)
+    ransack (4.1.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.5.0)
       psych (>= 4.0.0)
     regexp_parser (2.8.2)
@@ -370,6 +374,7 @@ DEPENDENCIES
   pundit
   rack-mini-profiler
   rails (~> 7.1.1)
+  ransack
   rubocop
   rubocop-minitest
   rubocop-performance

--- a/app/assets/styles/application.css
+++ b/app/assets/styles/application.css
@@ -2,20 +2,5 @@
 @import url("./theme.css");
 @import url("./components/entries.css");
 @import url("./components/forms.css");
+@import url("./components/homepage.css");
 @import url("./components/page.css");
-
-.homepage {
-  position: relative;
-  display: flex;
-  gap: 1rem;
-}
-
-.homepage__filters {
-  position: sticky;
-  top: 0.5rem;
-  left: 0;
-  flex-grow: 0;
-  flex-shrink: 0;
-  width: 15rem;
-  height: min-content;
-}

--- a/app/assets/styles/application.css
+++ b/app/assets/styles/application.css
@@ -3,3 +3,19 @@
 @import url("./components/entries.css");
 @import url("./components/forms.css");
 @import url("./components/page.css");
+
+.homepage {
+  position: relative;
+  display: flex;
+  gap: 1rem;
+}
+
+.homepage__filters {
+  position: sticky;
+  top: 0.5rem;
+  left: 0;
+  flex-grow: 0;
+  flex-shrink: 0;
+  width: 15rem;
+  height: min-content;
+}

--- a/app/assets/styles/components/forms.css
+++ b/app/assets/styles/components/forms.css
@@ -25,3 +25,15 @@
 .form:has(input[value="RssFeed"]:checked) [data-show-only="RssFeed"] {
   display: unset;
 }
+
+/* Radio buttons */
+.radio-buttons__options {
+  margin-block-start: 0;
+  padding-inline-start: 0;
+  list-style: none;
+
+  /* Add padding to nested options */
+  & .radio-buttons__options {
+    padding-inline-start: 1rem;
+  }
+}

--- a/app/assets/styles/components/homepage.css
+++ b/app/assets/styles/components/homepage.css
@@ -1,0 +1,23 @@
+.homepage {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  @media (--screen-md) {
+    flex-direction: row;
+  }
+}
+
+.homepage__filters {
+  flex-grow: 0;
+  flex-shrink: 0;
+  height: min-content;
+
+  @media (--screen-md) {
+    position: sticky;
+    top: 0.5rem;
+    left: 0;
+    width: 15rem;
+  }
+}

--- a/app/assets/styles/components/page.css
+++ b/app/assets/styles/components/page.css
@@ -1,7 +1,7 @@
 .page {
   max-width: var(--screen-sm);
-  margin-block: 1.5rem;
   margin-inline: auto;
+  padding-block: 1.5rem;
   padding-inline: 2rem;
 }
 

--- a/app/components/concerns/forms/has_options.rb
+++ b/app/components/concerns/forms/has_options.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Forms::HasOptions
+  extend ActiveSupport::Concern
+
+  included do
+    attr_reader :options, :value_method, :label_method
+
+    def initialize(options: [], value_method: :first, label_method: :second, **)
+      super(**)
+      @options = options.map { |opt| opt.is_a?(ApplicationRecord) ? opt : Array.wrap(opt) }
+      @label_method = label_method
+      @value_method = value_method
+    end
+  end
+end

--- a/app/components/forms/base_component.rb
+++ b/app/components/forms/base_component.rb
@@ -5,21 +5,20 @@ class Forms::BaseComponent < ViewComponent::Base
 
   # rubocop:disable Metrics/ParameterLists
   # We need to have a lot of parameters here, since this is a very generic component
-  def initialize(form:, name:, hint: nil, error: nil, disabled: false, options: [], **html_attrs)
+  def initialize(form:, name:, hint: nil, error: nil, disabled: false, **html_attrs)
     super
     @form = form
     @name = name
     @hint = hint
     @error = error
     @disabled = disabled
-    @options = options.map { |opt| Array.wrap(opt) }
     @class = html_attrs.delete(:class).presence || ''
     @html_attrs = html_attrs
   end
   # rubocop:enable Metrics/ParameterLists
 
   def error
-    @error.presence || (form.object && form.object.errors.full_messages_for(name).first)
+    @error.presence || (form.object.respond_to?(:errors) && form.object.errors.full_messages_for(name).first)
   end
 
   def valid?

--- a/app/components/forms/checkbox_component.html.erb
+++ b/app/components/forms/checkbox_component.html.erb
@@ -1,0 +1,12 @@
+<%= content_tag :div, class: ['checkbox', { 'checkbox--valid': valid? }, { 'checkbox--invalid': invalid? }, @class], **@html_attrs do %>
+  <div class="checkbox__field-wrapper">
+    <%= form.check_box name, class: 'checkbox__field', disabled: %>
+    <%= form.label name, class: 'checkbox__label' %>
+  </div>
+  <%- if hint.present? %>
+    <%= content_tag :span, hint, class: 'checkbox__hint' %>
+  <%- end %>
+  <%- if invalid? %>
+    <%= content_tag :span, error, class: 'checkbox__error' %>
+  <%- end %>
+<% end %>

--- a/app/components/forms/checkbox_component.rb
+++ b/app/components/forms/checkbox_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Forms::CheckboxComponent < Forms::BaseComponent
+end

--- a/app/components/forms/email_input_component.html.erb
+++ b/app/components/forms/email_input_component.html.erb
@@ -4,7 +4,7 @@
   <%- if options.present? %>
     <%= content_tag :datalist, id: element_id(:datalist) do %>
       <%- options.each do |opt| %>
-        <%= content_tag :option, opt[1].presence || opt[0], value: opt[0] %>
+        <%= content_tag :option, opt.send(label_method), value: opt.send(value_method) %>
       <%- end %>
     <% end %>
   <%- end %>

--- a/app/components/forms/email_input_component.rb
+++ b/app/components/forms/email_input_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Forms::EmailInputComponent < Forms::BaseComponent
+  include Forms::HasOptions
 end

--- a/app/components/forms/password_input_component.rb
+++ b/app/components/forms/password_input_component.rb
@@ -1,8 +1,4 @@
 # frozen_string_literal: true
 
 class Forms::PasswordInputComponent < Forms::BaseComponent
-  def initialize(**)
-    super(**)
-    raise ArgumentError, 'Options is not supported for password inputs' if options.present?
-  end
 end

--- a/app/components/forms/radio_input_component.html.erb
+++ b/app/components/forms/radio_input_component.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag :div, class: ['radio-buttons', { 'radio-buttons--valid': valid? }, { 'radio-buttons--invalid': invalid? }, @class], **@html_attrs do %>
   <%= form.label name, class: 'radio-buttons__label' %>
-  <%= form.collection_radio_buttons name, options, :first, :second, { disabled:, include_hidden: false } do |rb| %>
+  <%= form.collection_radio_buttons name, options, value_method, label_method, { disabled:, include_hidden: false } do |rb| %>
     <%= rb.radio_button class: 'radio-buttons__option-field', disabled: %>
     <%= rb.label class: 'radio-buttons__option-label' %>
   <% end %>

--- a/app/components/forms/radio_input_component.rb
+++ b/app/components/forms/radio_input_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Forms::RadioInputComponent < Forms::BaseComponent
+  include Forms::HasOptions
 end

--- a/app/components/forms/radio_tree_input_component.html.erb
+++ b/app/components/forms/radio_tree_input_component.html.erb
@@ -1,0 +1,40 @@
+<%= content_tag :div, class: ['radio-buttons', 'radio-buttons--tree', { 'radio-buttons--valid': valid? }, { 'radio-buttons--invalid': invalid? }, @class], **@html_attrs do %>
+  <%= form.label name, class: 'radio-buttons__label' %>
+
+  <%# ROOTS %>
+  <ul class="radio-buttons__options" data-tree-level="0">
+  <%- roots.each do |root| %>
+    <li>
+      <%= form.radio_button name, root.send(value_method), class: 'radio-buttons__option-field', disabled: %>
+      <%= form.label name, root.send(label_method), value: root.send(value_method), class: 'radio-buttons__option-label' %>
+    </li>
+
+    <%# Children %>
+    <ul class="radio-buttons__options" data-tree-level="1">
+    <%- children_for(root).each do |child| %>
+      <li>
+        <%= form.radio_button name, child.send(value_method), class: 'radio-buttons__option-field', disabled: %>
+        <%= form.label name, child.send(label_method), value: child.send(value_method), class: 'radio-buttons__option-label' %>
+      </li>
+
+      <%# Grandchildren %>
+      <ul class="radio-buttons__options" data-tree-level="2">
+      <%- children_for(child).each do |grandchild| %>
+        <li>
+          <%= form.radio_button name, grandchild.send(value_method), class: 'radio-buttons__option-field', disabled: %>
+          <%= form.label name, grandchild.send(label_method), value: grandchild.send(value_method), class: 'radio-buttons__option-label' %>
+        </li>
+      <%- end %>
+      </ul>
+    <%- end %>
+    </ul>
+  <%- end %>
+  </ul>
+
+  <%- if hint.present? %>
+    <%= content_tag :span, hint, class: 'radio-buttons__hint' %>
+  <%- end %>
+  <%- if invalid? %>
+    <%= content_tag :span, error, class: 'radio-buttons__error' %>
+  <%- end %>
+<% end %>

--- a/app/components/forms/radio_tree_input_component.rb
+++ b/app/components/forms/radio_tree_input_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Forms::RadioTreeInputComponent < Forms::BaseComponent
+  include Forms::HasOptions
+
+  def roots
+    @roots ||= options.filter { |opt| opt.parent_id.nil? }
+  end
+
+  def children_for(option)
+    options.filter { |opt| opt.parent_id == option.id }
+  end
+end

--- a/app/components/forms/text_input_component.html.erb
+++ b/app/components/forms/text_input_component.html.erb
@@ -4,7 +4,7 @@
   <%- if options.present? %>
     <%= content_tag :datalist, id: element_id(:datalist) do %>
       <%- options.each do |opt| %>
-        <%= content_tag :option, opt[1].presence || opt[0], value: opt[0] %>
+        <%= content_tag :option, opt.send(label_method), value: opt.send(value_method) %>
       <%- end %>
     <% end %>
   <%- end %>

--- a/app/components/forms/text_input_component.rb
+++ b/app/components/forms/text_input_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Forms::TextInputComponent < Forms::BaseComponent
+  include Forms::HasOptions
 end

--- a/app/components/forms/url_input_component.html.erb
+++ b/app/components/forms/url_input_component.html.erb
@@ -4,7 +4,7 @@
     <%- if options.present? %>
     <%= content_tag :datalist, id: element_id(:datalist) do %>
       <%- options.each do |opt| %>
-        <%= content_tag :option, opt[1].presence || opt[0], value: opt[0] %>
+        <%= content_tag :option, opt.send(label_method), value: opt.send(value_method) %>
       <%- end %>
     <% end %>
   <%- end %>

--- a/app/components/forms/url_input_component.rb
+++ b/app/components/forms/url_input_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Forms::UrlInputComponent < Forms::BaseComponent
+  include Forms::HasOptions
 end

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -7,6 +7,7 @@ class EntriesController < ApplicationController
     authorize Entry
     @query = policy_scope(Entry).includes(:subscription).ransack(params[:q])
     @pagy, @entries = pagy(@query.result.order(published_at: :desc))
+    @category_options = policy_scope(Category)
   end
 
   def show; end

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -5,7 +5,8 @@ class EntriesController < ApplicationController
 
   def index
     authorize Entry
-    @pagy, @entries = pagy(policy_scope(Entry).includes(:subscription).order(published_at: :desc))
+    @query = policy_scope(Entry).includes(:subscription).ransack(params[:q])
+    @pagy, @entries = pagy(@query.result.order(published_at: :desc))
   end
 
   def show; end

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -5,7 +5,7 @@ class EntriesController < ApplicationController
 
   def index
     authorize Entry
-    @query = policy_scope(Entry).includes(:subscription).ransack(params[:q])
+    @query = policy_scope(Entry).includes(:subscription).ransack(search_params)
     @pagy, @entries = pagy(@query.result.order(published_at: :desc))
     @category_options = policy_scope(Category)
   end
@@ -33,5 +33,10 @@ class EntriesController < ApplicationController
     attrs = permitted_attributes(@entry)
     attrs[:read_at] = attrs.delete(:read) == 'true' ? DateTime.current : nil
     attrs
+  end
+
+  def search_params
+    # Provide default params if no params were passed
+    params.fetch(:q, {}).permit(policy(Entry).permitted_attributes_for_index)
   end
 end

--- a/app/lib/component_form_builder.rb
+++ b/app/lib/component_form_builder.rb
@@ -7,7 +7,8 @@
 
 class ComponentFormBuilder < ActionView::Helpers::FormBuilder
   COMPONENT_MAP = {
-    string: 'Text'
+    string: 'Forms::TextInputComponent',
+    boolean: 'Forms::CheckboxComponent'
   }.freeze
 
   def input(method, as: nil, **args, &block)
@@ -26,7 +27,7 @@ class ComponentFormBuilder < ActionView::Helpers::FormBuilder
 
   def component_klass(method:, as:)
     type = as.presence || input_type(method:)
-    "Forms::#{COMPONENT_MAP[type].presence || type.capitalize}InputComponent".constantize
+    (COMPONENT_MAP[type].presence || "Forms::#{type.to_s.camelize}InputComponent").constantize
   end
 
   def input_type(method:)

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,4 +2,15 @@
 
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+
+  # Ransack 4.0 introduced allowlisting of attributes and associations
+  # We disable this, since our models should not be aware of the current user
+  # Filtering of params should happen in the controller and not in the model
+  def self.ransackable_attributes(_auth_object = nil)
+    authorizable_ransackable_attributes
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    authorizable_ransackable_associations
+  end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Category < ApplicationRecord
+  include WithRecursiveSearch
+
   belongs_to :parent, class_name: 'Category', optional: true, inverse_of: :children
   has_many :children, class_name: 'Category', foreign_key: :parent_id, dependent: :destroy, inverse_of: :parent
   has_many :subscriptions, dependent: :restrict_with_error

--- a/app/models/concerns/with_recursive_search.rb
+++ b/app/models/concerns/with_recursive_search.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module WithRecursiveSearch
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def descendants_by_id(*ids, include_self: false)
+      with_recursive_query(ids, recursive_alias[:id].eq(arel_table[:parent_id]), include_self:)
+    end
+
+    def ancestors_by_id(*ids, include_self: false)
+      with_recursive_query(ids, recursive_alias[:parent_id].eq(arel_table[:id]), include_self:)
+    end
+
+    private
+
+    def recursive_alias
+      Arel::Table.new('categories_tree')
+    end
+
+    def with_recursive_query(ids, on_clause, include_self:)
+      alias_definition = Arel::Nodes::SqlLiteral.new("#{recursive_alias.name}(#{column_names.join(',')})")
+      cte = Arel::Nodes::TableAlias.new(send(:sub_query_for_recursive, ids, on_clause), alias_definition)
+      query = recursive_alias.project('*')
+      query.where(recursive_alias[:id].not_in(ids)) unless include_self
+      find_by_sql(query.with(:recursive, cte))
+    end
+
+    def sub_query_for_recursive(ids, on_clause)
+      union_query = select(column_names.map { |c| arel_table[c] }).arel.join(recursive_alias).on(on_clause)
+      select(column_names).where(id: ids).arel.union(:all, union_query)
+    end
+  end
+end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -42,5 +42,9 @@ class Entry < ApplicationRecord
     read_at.present?
   end
 
+  def self.ransackable_scopes(_auth_object = nil)
+    %i[unread]
+  end
+
   delegate :user_id, to: :subscription
 end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -21,6 +21,8 @@ class Entry < ApplicationRecord
 
   scope :read, -> { where.not(read_at: nil) }
   scope :unread, -> { where(read_at: nil) }
+  # Delegate scope to `Subscription`
+  scope :by_category, ->(cat_id) { where(subscription: Subscription.by_category(cat_id)) }
 
   def self.from_feedjira_entry(entry)
     attrs = {}
@@ -43,7 +45,7 @@ class Entry < ApplicationRecord
   end
 
   def self.ransackable_scopes(_auth_object = nil)
-    %i[unread]
+    %i[unread by_category]
   end
 
   delegate :user_id, to: :subscription

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -14,6 +14,8 @@ class Subscription < ApplicationRecord
 
   before_validation :create_categories_from_text
 
+  scope :by_category, ->(cat_id) { where(category: Category.descendants_by_id(cat_id, include_self: true)) }
+
   def refreshable?
     subscribable.respond_to? :refresh!
   end

--- a/app/policies/category_policy.rb
+++ b/app/policies/category_policy.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CategoryPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      return scope.none if user.blank?
+
+      # We filter by the users subscriptions and all ancestors, and use this to create a regular query chain
+      scope.where(id: Category.ancestors_by_id(scope.where(id: user.subscriptions.select(:category_id)).select(:id),
+                                               include_self: true))
+    end
+  end
+end

--- a/app/policies/entry_policy.rb
+++ b/app/policies/entry_policy.rb
@@ -24,7 +24,11 @@ class EntryPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    %i[read]
+    %i[read] if user.present?
+  end
+
+  def permitted_attributes_for_index
+    %i[unread by_category] if user.present?
   end
 
   private

--- a/app/views/entries/index.html.erb
+++ b/app/views/entries/index.html.erb
@@ -1,30 +1,39 @@
 <%= content_for :page_title, t('.page_title') %>
 
-<table class="table">
-  <thead class="table__head">
-    <tr class="table__row table__row--head">
-      <%= content_tag :td, Entry.human_attribute_name(:feed), class: 'table__cell' %>
-      <%= content_tag :td, Entry.human_attribute_name(:title), class: 'table__cell' %>
-      <%= content_tag :td, Entry.human_attribute_name(:author), class: 'table__cell' %>
-      <%= content_tag :td, Entry.human_attribute_name(:published_at), class: 'table__cell' %>
-      <%= content_tag :td, Entry.human_attribute_name(:read), class: 'table__cell' %>
-      <%= content_tag :td, t('.actions'), class: 'table__cell' %>
-    </tr>
-  </thead>
-  <tbody class="table__body">
-    <%- @entries.each do |entry| %>
-      <tr class="table__row">
-        <%= content_tag :td, entry.subscription.name, class: 'table__cell' %>
-        <%= content_tag :td, entry.title, class: 'table__cell' %>
-        <%= content_tag :td, entry.author, class: 'table__cell' %>
-        <%= content_tag :td, entry.published_at.present? ? l(entry.published_at) : t('.published_at_unknown'), class: 'table__cell' %>
-        <%= content_tag :td, entry.read?, class: 'table__cell' %>
-        <%= content_tag :td, class: 'table__cell' do %>
-          <%= link_to t('.show'), entry, class: 'table__link' %>
-        <% end %>
-      </tr>
-    <%- end %>
-  </tbody>
-</table>
-
-<%== pagy_nav(@pagy) %>
+<div class="homepage">
+  <div class="homepage__filters">
+    <%= search_form_for @query, url: url_for, builder: ComponentFormBuilder do |form| %>
+      <%= form.input :unread, as: :boolean %>
+      <%= form.submit %>
+    <% end %>
+  </div>
+  <div>
+    <table class="table">
+      <thead class="table__head">
+        <tr class="table__row table__row--head">
+          <%= content_tag :td, Entry.human_attribute_name(:feed), class: 'table__cell' %>
+          <%= content_tag :td, Entry.human_attribute_name(:title), class: 'table__cell' %>
+          <%= content_tag :td, Entry.human_attribute_name(:author), class: 'table__cell' %>
+          <%= content_tag :td, Entry.human_attribute_name(:published_at), class: 'table__cell' %>
+          <%= content_tag :td, Entry.human_attribute_name(:read), class: 'table__cell' %>
+          <%= content_tag :td, t('.actions'), class: 'table__cell' %>
+        </tr>
+      </thead>
+      <tbody class="table__body">
+        <%- @entries.each do |entry| %>
+          <tr class="table__row">
+            <%= content_tag :td, entry.subscription.name, class: 'table__cell' %>
+            <%= content_tag :td, entry.title, class: 'table__cell' %>
+            <%= content_tag :td, entry.author, class: 'table__cell' %>
+            <%= content_tag :td, entry.published_at.present? ? l(entry.published_at) : t('.published_at_unknown'), class: 'table__cell' %>
+            <%= content_tag :td, entry.read?, class: 'table__cell' %>
+            <%= content_tag :td, class: 'table__cell' do %>
+              <%= link_to t('.show'), entry, class: 'table__link' %>
+            <% end %>
+          </tr>
+        <%- end %>
+      </tbody>
+    </table>
+    <%== pagy_nav(@pagy) %>
+  </div>
+</div>

--- a/app/views/entries/index.html.erb
+++ b/app/views/entries/index.html.erb
@@ -4,6 +4,7 @@
   <div class="homepage__filters">
     <%= search_form_for @query, url: url_for, builder: ComponentFormBuilder do |form| %>
       <%= form.input :unread, as: :boolean %>
+      <%= form.input :by_category, as: :radio_tree, options: @category_options %>
       <%= form.submit %>
     <% end %>
   </div>

--- a/app/views/entries/index.html.erb
+++ b/app/views/entries/index.html.erb
@@ -4,8 +4,8 @@
   <div class="homepage__filters">
     <%= search_form_for @query, url: url_for, builder: ComponentFormBuilder do |form| %>
       <%= form.input :unread, as: :boolean %>
-      <%= form.input :by_category, as: :radio_tree, options: @category_options %>
-      <%= form.submit %>
+      <%= form.input :by_category, as: :radio_tree, options: @category_options, value_method: :id, label_method: :name %>
+      <%= form.submit t('.search') %>
     <% end %>
   </div>
   <div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,7 @@ en:
       page_title: Overview
       published_at_unknown: "Unknown"
       show: Show
+      search: 'Search'
     show:
       page_title: "%{entry_title}"
       mark_as_read: Mark as read

--- a/gemset.nix
+++ b/gemset.nix
@@ -974,6 +974,17 @@
     };
     version = "13.0.6";
   };
+  ransack = {
+    dependencies = ["activerecord" "activesupport" "i18n"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "00c9g182v9pfdr5652vzphjdydjv02q3whrcg8a9zgi9vq721nq1";
+      type = "gem";
+    };
+    version = "4.1.1";
+  };
   rdoc = {
     dependencies = ["psych"];
     groups = ["default" "development" "production" "test"];

--- a/test/components/forms/checkbox_component_test.rb
+++ b/test/components/forms/checkbox_component_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Forms::CheckboxComponentTest < ViewComponent::TestCase
+  include FormComponentsHelper
+
+  setup do
+    @object = build(:user, :admin)
+    @form = form_with(@object)
+  end
+
+  test 'should render checkbox' do
+    render_inline(Forms::CheckboxComponent.new(form: @form, name: :admin))
+
+    assert_selector '.checkbox'
+    assert_selector '.checkbox__label', text: 'Admin'
+    assert_selector 'input[type="checkbox"][value="1"][checked="checked"].checkbox__field'
+  end
+
+  test 'should render hint and error when values are passed' do
+    render_inline(Forms::CheckboxComponent.new(form: @form, name: :admin,
+                                               hint: 'Use with caution!',
+                                               error: 'This field is required'))
+
+    assert_selector '.checkbox.checkbox--invalid'
+    assert_selector '.checkbox__hint', text: 'Use with caution!'
+    assert_selector '.checkbox__error', text: 'This field is required'
+  end
+
+  test 'should render error from object' do
+    @object.errors.add(:admin, 'Some error')
+
+    render_inline(Forms::CheckboxComponent.new(form: @form, name: :admin))
+
+    assert_selector '.checkbox__error', text: 'Some error'
+  end
+
+  test 'should render additional html attributes' do
+    render_inline(Forms::CheckboxComponent.new(form: @form, name: :admin, class: 'my-class',
+                                               data: { foo: :bar }))
+
+    assert_selector '.checkbox.my-class[data-foo="bar"]'
+  end
+end

--- a/test/components/forms/email_input_component_test.rb
+++ b/test/components/forms/email_input_component_test.rb
@@ -45,7 +45,7 @@ class Forms::EmailInputComponentTest < ViewComponent::TestCase
 
   test 'should render datalist if passed options' do
     options = ['opt1', ['opt2', 'Option 2']]
-    render_inline(Forms::EmailInputComponent.new(form: @form, name: :email, options:))
+    render_inline(Forms::EmailInputComponent.new(form: @form, name: :email, options:, label_method: :last))
 
     assert_selector 'datalist#user_email_datalist'
     assert_selector 'datalist option[value="opt1"]', text: 'opt1'

--- a/test/components/forms/password_input_component_test.rb
+++ b/test/components/forms/password_input_component_test.rb
@@ -43,12 +43,4 @@ class Forms::PasswordInputComponentTest < ViewComponent::TestCase
 
     assert_selector '.input.my-class[data-foo="bar"]'
   end
-
-  test 'should raise error if passed options' do
-    options = ['opt1', ['opt2', 'Option 2']]
-
-    assert_raises ArgumentError do
-      render_inline(Forms::PasswordInputComponent.new(form: @form, name: :password, options:))
-    end
-  end
 end

--- a/test/components/forms/radio_tree_input_component_test.rb
+++ b/test/components/forms/radio_tree_input_component_test.rb
@@ -38,7 +38,8 @@ class Forms::RadioTreeInputComponentTest < ViewComponent::TestCase
   end
 
   test 'should render hint and error when value is passed' do
-    render_inline(Forms::RadioTreeInputComponent.new(form: @form, name: :category, options: @options, value_method: :name, label_method: :name,
+    render_inline(Forms::RadioTreeInputComponent.new(form: @form, name: :category, options: @options,
+                                                     value_method: :name, label_method: :name,
                                                      hint: 'foobar@example.org',
                                                      error: 'This field is required'))
 
@@ -57,7 +58,8 @@ class Forms::RadioTreeInputComponentTest < ViewComponent::TestCase
   end
 
   test 'should render additional html attributes' do
-    render_inline(Forms::RadioTreeInputComponent.new(form: @form, name: :category, options: @options, value_method: :name, label_method: :name,
+    render_inline(Forms::RadioTreeInputComponent.new(form: @form, name: :category, options: @options,
+                                                     value_method: :name, label_method: :name,
                                                      class: 'my-class',
                                                      data: { foo: :bar }))
 

--- a/test/components/forms/radio_tree_input_component_test.rb
+++ b/test/components/forms/radio_tree_input_component_test.rb
@@ -30,8 +30,6 @@ class Forms::RadioTreeInputComponentTest < ViewComponent::TestCase
     page = render_inline(Forms::RadioTreeInputComponent.new(form: @form, name: :category, options: @options,
                                                             value_method: :name, label_method: :name))
 
-    pp page.to_html
-
     assert_selector 'ul[data-tree-level="0"] > li > input[type="radio"][value="parent"]'
     assert_selector 'ul[data-tree-level="1"] > li > input[type="radio"]', count: 2
     assert_selector 'ul[data-tree-level="2"] > li > input[type="radio"][value="child"]'

--- a/test/components/forms/radio_tree_input_component_test.rb
+++ b/test/components/forms/radio_tree_input_component_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Forms::RadioTreeInputComponentTest < ViewComponent::TestCase
+  include FormComponentsHelper
+
+  setup do
+    # Create some categories to use as options
+    parent = create(:category, name: 'parent')
+    record = create(:category, parent:, name: 'record')
+    create(:category, parent:, name: 'sibling')
+    create(:category, parent: record, name: 'child')
+
+    @object = build(:subscription, category: record)
+    @form = form_with(@object)
+    @options = Category.all
+  end
+
+  test 'should render input with options' do
+    render_inline(Forms::RadioTreeInputComponent.new(form: @form, name: :category, options: @options,
+                                                     value_method: :name, label_method: :name))
+
+    assert_selector '.radio-buttons.radio-buttons--tree'
+    assert_selector '.radio-buttons__label', text: 'Category'
+    assert_selector 'input[type="radio"].radio-buttons__option-field', count: 4
+  end
+
+  test 'should render options as tree' do
+    page = render_inline(Forms::RadioTreeInputComponent.new(form: @form, name: :category, options: @options,
+                                                            value_method: :name, label_method: :name))
+
+    pp page.to_html
+
+    assert_selector 'ul[data-tree-level="0"] > li > input[type="radio"][value="parent"]'
+    assert_selector 'ul[data-tree-level="1"] > li > input[type="radio"]', count: 2
+    assert_selector 'ul[data-tree-level="2"] > li > input[type="radio"][value="child"]'
+  end
+
+  test 'should render hint and error when value is passed' do
+    render_inline(Forms::RadioTreeInputComponent.new(form: @form, name: :category, options: @options, value_method: :name, label_method: :name,
+                                                     hint: 'foobar@example.org',
+                                                     error: 'This field is required'))
+
+    assert_selector '.radio-buttons.radio-buttons--invalid'
+    assert_selector '.radio-buttons__hint', text: 'foobar@example.org'
+    assert_selector '.radio-buttons__error', text: 'This field is required'
+  end
+
+  test 'should render error from object' do
+    @object.errors.add(:category, 'Some error')
+
+    render_inline(Forms::RadioTreeInputComponent.new(form: @form, name: :category, options: @options,
+                                                     value_method: :name, label_method: :name))
+
+    assert_selector '.radio-buttons__error', text: 'Some error'
+  end
+
+  test 'should render additional html attributes' do
+    render_inline(Forms::RadioTreeInputComponent.new(form: @form, name: :category, options: @options, value_method: :name, label_method: :name,
+                                                     class: 'my-class',
+                                                     data: { foo: :bar }))
+
+    assert_selector '.radio-buttons.my-class[data-foo="bar"]'
+  end
+end

--- a/test/components/forms/radio_tree_input_component_test.rb
+++ b/test/components/forms/radio_tree_input_component_test.rb
@@ -27,8 +27,8 @@ class Forms::RadioTreeInputComponentTest < ViewComponent::TestCase
   end
 
   test 'should render options as tree' do
-    page = render_inline(Forms::RadioTreeInputComponent.new(form: @form, name: :category, options: @options,
-                                                            value_method: :name, label_method: :name))
+    render_inline(Forms::RadioTreeInputComponent.new(form: @form, name: :category, options: @options,
+                                                     value_method: :name, label_method: :name))
 
     assert_selector 'ul[data-tree-level="0"] > li > input[type="radio"][value="parent"]'
     assert_selector 'ul[data-tree-level="1"] > li > input[type="radio"]', count: 2

--- a/test/components/forms/text_input_component_test.rb
+++ b/test/components/forms/text_input_component_test.rb
@@ -44,11 +44,11 @@ class Forms::TextInputComponentTest < ViewComponent::TestCase
   end
 
   test 'should render datalist if passed options' do
-    options = ['opt1', ['opt2', 'Option 2']]
+    options = [['opt1', 'Option 1'], ['opt2', 'Option 2']]
     render_inline(Forms::TextInputComponent.new(form: @form, name: :name, options:))
 
     assert_selector 'datalist#subscription_name_datalist'
-    assert_selector 'datalist option[value="opt1"]', text: 'opt1'
+    assert_selector 'datalist option[value="opt1"]', text: 'Option 1'
     assert_selector 'datalist option[value="opt2"]', text: 'Option 2'
   end
 end

--- a/test/components/forms/url_input_component_test.rb
+++ b/test/components/forms/url_input_component_test.rb
@@ -44,11 +44,11 @@ class Forms::UrlInputComponentTest < ViewComponent::TestCase
   end
 
   test 'should render datalist if passed options' do
-    options = ['opt1', ['opt2', 'Option 2']]
+    options = [['opt1', 'Option 1'], ['opt2', 'Option 2']]
     render_inline(Forms::UrlInputComponent.new(form: @form, name: :url, options:))
 
     assert_selector 'datalist#rss_feed_url_datalist'
-    assert_selector 'datalist option[value="opt1"]', text: 'opt1'
+    assert_selector 'datalist option[value="opt1"]', text: 'Option 1'
     assert_selector 'datalist option[value="opt2"]', text: 'Option 2'
   end
 end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
   factory :user do
     email { Faker::Internet.unique.email }
     password { Faker::Internet.password(min_length: 12) }
+
+    trait :admin do
+      admin { true }
+    end
   end
 end

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -31,4 +31,49 @@ class CategoryTest < ActiveSupport::TestCase
       # rubocop:enable Rails/SkipsModelValidations
     end
   end
+
+  # `WithRecursiveSearch` concern
+  test 'should find ancestors based on ids' do
+    parent = create(:category)
+    record = create(:category, parent:)
+    sibling = create(:category, parent:)
+    child = create(:category, parent: record)
+
+    assert_equal 2, Category.ancestors_by_id(child.id).length
+    assert_equal 1, Category.ancestors_by_id(record.id).length
+    assert_equal 1, Category.ancestors_by_id(sibling.id).length
+  end
+
+  test 'should find descendants based on ids' do
+    parent = create(:category)
+    record = create(:category, parent:)
+    sibling = create(:category, parent:)
+    create(:category, parent: record)
+
+    assert_equal 3, Category.descendants_by_id(parent.id).length
+    assert_equal 1, Category.descendants_by_id(record.id).length
+    assert_equal 0, Category.descendants_by_id(sibling.id).length
+  end
+
+  test 'should find ancestors with self based on ids' do
+    parent = create(:category)
+    record = create(:category, parent:)
+    sibling = create(:category, parent:)
+    child = create(:category, parent: record)
+
+    assert_equal 3, Category.ancestors_by_id(child.id, include_self: true).length
+    assert_equal 2, Category.ancestors_by_id(record.id, include_self: true).length
+    assert_equal 2, Category.ancestors_by_id(sibling.id, include_self: true).length
+  end
+
+  test 'should find descendants with self based on ids' do
+    parent = create(:category)
+    record = create(:category, parent:)
+    sibling = create(:category, parent:)
+    create(:category, parent: record)
+
+    assert_equal 4, Category.descendants_by_id(parent.id, include_self: true).length
+    assert_equal 2, Category.descendants_by_id(record.id, include_self: true).length
+    assert_equal 1, Category.descendants_by_id(sibling.id, include_self: true).length
+  end
 end

--- a/test/policies/category_policy_test.rb
+++ b/test/policies/category_policy_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CategoryPolicyTest < ActiveSupport::TestCase
+  def test_scope; end
+
+  def test_show; end
+
+  def test_create; end
+
+  def test_update; end
+
+  def test_destroy; end
+end


### PR DESCRIPTION
This PR allows user to filter the entries on `entries#index`. A user can filter by unread status or by the category of the subscription