### PR TITLE
Store entry search accross navigation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem 'pagy' # Use pagy for pagination
 gem 'pg' # Use postgresql as the database for Active Record
 gem 'puma' # Use the Puma web server [https://github.com/puma/puma]
 gem 'pundit' # Use pundit for easy authorization
-gem 'ransack' # Use ransack for searching and sorting
 gem 'turbo-rails' # Use Turbo for progressive enhancement of requests
 gem 'view_component' # Use ViewComponent to replace partials
 gem 'vite_rails' # Use ViteRails to compile assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,10 +256,6 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.1.0)
-    ransack (4.1.1)
-      activerecord (>= 6.1.5)
-      activesupport (>= 6.1.5)
-      i18n
     rdoc (6.6.0)
       psych (>= 4.0.0)
     regexp_parser (2.8.2)
@@ -374,7 +370,6 @@ DEPENDENCIES
   pundit
   rack-mini-profiler
   rails (~> 7.1.1)
-  ransack
   rubocop
   rubocop-minitest
   rubocop-performance

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class EntriesController < ApplicationController
+  before_action :set_entry_search, only: %i[index]
   before_action :set_entry, only: %i[show update destroy]
 
   def index
     authorize Entry
-    @query = policy_scope(Entry).includes(:subscription).ransack(search_params)
-    @pagy, @entries = pagy(@query.result.order(published_at: :desc))
+    @pagy, @entries = pagy(@entry_search.apply(policy_scope(Entry).includes(:subscription)).order(published_at: :desc))
     @category_options = policy_scope(Category)
   end
 
@@ -35,8 +35,8 @@ class EntriesController < ApplicationController
     attrs
   end
 
-  def search_params
-    # Provide default params if no params were passed
-    params.fetch(:q, {}).permit(policy(Entry).permitted_attributes_for_index)
+  def set_entry_search
+    search_params = params.fetch(:search, {}).permit(policy(Entry).permitted_attributes_for_index)
+    @entry_search = EntrySearch.new(**search_params)
   end
 end

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -38,5 +38,6 @@ class EntriesController < ApplicationController
   def set_entry_search
     search_params = params.fetch(:search, {}).permit(policy(Entry).permitted_attributes_for_index)
     @entry_search = EntrySearch.new(**search_params)
+    session[:entry_search] = @entry_search.to_h
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,15 +2,4 @@
 
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
-
-  # Ransack 4.0 introduced allowlisting of attributes and associations
-  # We disable this, since our models should not be aware of the current user
-  # Filtering of params should happen in the controller and not in the model
-  def self.ransackable_attributes(_auth_object = nil)
-    authorizable_ransackable_attributes
-  end
-
-  def self.ransackable_associations(_auth_object = nil)
-    authorizable_ransackable_associations
-  end
 end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -44,14 +44,5 @@ class Entry < ApplicationRecord
     read_at.present?
   end
 
-  def self.ransackable_scopes(_auth_object = nil)
-    %i[unread by_category]
-  end
-
-  def self.ransackable_scopes_skip_sanitize_args
-    # Make sure Ransack doesn't treat `by_category(1)` as a boolean
-    %i[by_category]
-  end
-
   delegate :user_id, to: :subscription
 end

--- a/app/models/entry_search.rb
+++ b/app/models/entry_search.rb
@@ -20,6 +20,7 @@ class EntrySearch
   end
 
   alias unread? unread
+  alias to_h to_hash
 
   private
 

--- a/app/models/entry_search.rb
+++ b/app/models/entry_search.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class EntrySearch
+  extend ActiveModel::Naming
+
+  attr_reader :unread, :category_id
+
+  def initialize(**values)
+    values.symbolize_keys!
+    @unread = ActiveModel::Type::Boolean.new.cast(values[:unread])
+    @category_id = values[:category_id]
+  end
+
+  def apply(entry_scope)
+    scopes.inject(entry_scope) { |entries, scope| entries.send(*scope) }
+  end
+
+  def to_hash
+    { category_id:, unread: }.compact
+  end
+
+  alias unread? unread
+
+  private
+
+  def scopes
+    scopes = []
+    scopes.push([:unread]) if unread?
+    scopes.push([:by_category, category_id]) if category_id.present?
+    scopes
+  end
+end

--- a/app/policies/entry_policy.rb
+++ b/app/policies/entry_policy.rb
@@ -28,7 +28,7 @@ class EntryPolicy < ApplicationPolicy
   end
 
   def permitted_attributes_for_index
-    %i[unread by_category] if user.present?
+    %i[unread category_id] if user.present?
   end
 
   private

--- a/app/views/entries/index.html.erb
+++ b/app/views/entries/index.html.erb
@@ -2,9 +2,9 @@
 
 <div class="homepage">
   <div class="homepage__filters">
-    <%= search_form_for @query, url: url_for, builder: ComponentFormBuilder do |form| %>
+    <%= form_with model: @entry_search, scope: :search, method: :get, url: url_for do |form| %>
       <%= form.input :unread, as: :boolean %>
-      <%= form.input :by_category, as: :radio_tree, options: @category_options, value_method: :id, label_method: :name %>
+      <%= form.input :category_id, as: :radio_tree, options: @category_options, value_method: :id, label_method: :name %>
       <%= form.submit t('.search') %>
     <% end %>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
       <%= content_tag :h1, yield(:page_title), class: 'header__title' %>
       <nav class="header__nav">
         <%- if current_user.present? %>
-          <%= link_to t('.home'), root_path %>
+          <%= link_to t('.home'), root_path(search: session[:entry_search]) %>
           <%= link_to t('.subscriptions'), subscriptions_path %>
           <%= link_to t('.sign_out'), destroy_session_path, data: { turbo_method: :delete } %>
           <%- if current_user.admin? %>

--- a/gemset.nix
+++ b/gemset.nix
@@ -974,17 +974,6 @@
     };
     version = "13.1.0";
   };
-  ransack = {
-    dependencies = ["activerecord" "activesupport" "i18n"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "00c9g182v9pfdr5652vzphjdydjv02q3whrcg8a9zgi9vq721nq1";
-      type = "gem";
-    };
-    version = "4.1.1";
-  };
   rdoc = {
     dependencies = ["psych"];
     groups = ["default" "development" "production" "test"];

--- a/test/controllers/entries_controller_test.rb
+++ b/test/controllers/entries_controller_test.rb
@@ -23,6 +23,23 @@ class EntriesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_session_path
   end
 
+  test 'should get store search in session' do
+    sign_in @user
+
+    get entries_url(search: { unread: '1' })
+
+    assert_response :success
+    assert_equal ({ unread: true }), session[:entry_search]
+  end
+
+  test 'should use stored search for `home` link' do
+    sign_in @user
+
+    get entries_url(search: { unread: '1' })
+
+    assert_select '[href="/?search%5Bunread%5D=true"]', text: 'Home'
+  end
+
   # Show
   test 'should get show' do
     sign_in @user

--- a/test/models/entry_search_test.rb
+++ b/test/models/entry_search_test.rb
@@ -17,6 +17,7 @@ class EntrySearchTest < ActiveSupport::TestCase
     search = EntrySearch.new(unread: true)
 
     result = search.apply(Entry)
+
     assert_equal 1, result.length
     assert_equal unread_entry, result.first
   end
@@ -29,6 +30,7 @@ class EntrySearchTest < ActiveSupport::TestCase
     search = EntrySearch.new(category_id: category.id)
 
     result = search.apply(Entry)
+
     assert_equal 1, result.length
     assert_equal entry, result.first
   end

--- a/test/models/entry_search_test.rb
+++ b/test/models/entry_search_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class EntrySearchTest < ActiveSupport::TestCase
+  test 'should initialize with keywords' do
+    search = EntrySearch.new(unread: true, category_id: 1)
+
+    assert_predicate search, :unread?
+    assert_equal 1, search.category_id
+  end
+
+  test 'should filter unread entries' do
+    unread_entry = create(:entry, read_at: nil)
+    create(:entry, read_at: 1.hour.ago)
+
+    search = EntrySearch.new(unread: true)
+
+    result = search.apply(Entry)
+    assert_equal 1, result.length
+    assert_equal unread_entry, result.first
+  end
+
+  test 'should filter entries by category' do
+    category = create(:category)
+    entry = create(:entry, subscription: build(:subscription, category:))
+    create(:entry, subscription: build(:subscription, category: create(:category)))
+
+    search = EntrySearch.new(category_id: category.id)
+
+    result = search.apply(Entry)
+    assert_equal 1, result.length
+    assert_equal entry, result.first
+  end
+end


### PR DESCRIPTION
fix #117 

In this PR, I've made sure that we can store the search in entries (on the homepage) in the params for easier navigation.
In order to accomplish this I went with a custom, non-persistent model `EntrySearch` (to replace ransack) that keeps our search params and can translate these to the correct filters.