### PR TITLE
Fix parsing srcset with comma in url

### DIFF
--- a/app/components/entry_component.rb
+++ b/app/components/entry_component.rb
@@ -32,7 +32,8 @@ class EntryComponent < ViewComponent::Base
   private
 
   def find_proxy_blob_for_url(url)
-    proxy = proxied_images.find { |p| p.url == entry.normalize_url(url) }
+    normalized_url = entry.normalize_url(url)
+    proxy = proxied_images.find { |p| p.url == normalized_url }
     return url unless proxy.present? && proxy.image.attached?
 
     helpers.rails_blob_path(proxy.image)

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RichTextTest < ActiveSupport::TestCase
+  test 'should detect url is srcset' do
+    text = RichText.new(
+      text: '<div><img srcset="https://example.com/image.jpg, https://example.com/image-2.jpg x2" /></div>'
+    )
+
+    result = []
+    text.handle_img_urls do |url|
+      result.push(url)
+      url
+    end
+
+    assert_equal 2, result.length
+    assert_equal 'https://example.com/image.jpg', result.first
+    assert_equal 'https://example.com/image-2.jpg', result.second
+  end
+
+  test 'should handle commas in srcset urls' do
+    text = RichText.new(
+      text: '<div><img srcset="https://example.com/image.jpg?a=b,21, https://example.com/image,2.jpg x2" /></div>'
+    )
+
+    result = []
+    text.handle_img_urls do |url|
+      result.push(url)
+      url
+    end
+
+    assert_equal 2, result.length
+    assert_equal 'https://example.com/image.jpg?a=b,21', result.first
+    assert_equal 'https://example.com/image,2.jpg', result.second
+  end
+
+  test 'should handle weird whitespace in srcset urls' do
+    text = RichText.new(
+      text: '<div><img srcset=" https://example.com/image.jpg  ,https://example.com/image-2.jpg (x1 x2) " /></div>'
+    )
+
+    result = []
+    text.handle_img_urls do |url|
+      result.push(url)
+      url
+    end
+
+    assert_equal 2, result.length
+    assert_equal 'https://example.com/image.jpg', result.first
+    assert_equal 'https://example.com/image-2.jpg', result.second
+  end
+end


### PR DESCRIPTION
This PR replaces the naive parsing of `srcset` attributes with a more robust implementation, based on the html spec. This fixes a bug where we would split urls containing a comma inside the url.