### PR TITLE
Fix entries controller responding with 404 when logged out/unauthorized

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -28,7 +28,7 @@ class EntriesController < ApplicationController
   private
 
   def set_entry
-    @entry = policy_scope(Entry).find params[:id]
+    @entry = Entry.find params[:id]
     authorize @entry
   end
 


### PR DESCRIPTION
Because of the policy scope, no record can ever be found when logged out, resulting in a 404 instead of a 302 to the sign in page.