### PR TITLE
Update config for postfix

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -268,8 +268,12 @@ in
             "argv=${relayMailScript}"
           ];
         };
-        sslCert = "${certDir}/cert.pem";
-        sslKey = "${certDir}/key.pem";
+        config = {
+          smtpd_tls_chain_files = [
+            "${certDir}/key.pem"
+            "${certDir}/cert.pem"
+          ];
+        };
         extraConfig = ''
           notify_classes = resource, software, delay, 2bounce, bounce
         '';


### PR DESCRIPTION
The old `sslKey` and `sslCert` options are deprecated in nixos.