### PR TITLE
Fix format of postfix settings

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -274,9 +274,9 @@ in
             "${certDir}/cert.pem"
           ];
         };
-        settings.main = ''
-          notify_classes = resource, software, delay, 2bounce, bounce
-        '';
+        settings.main = {
+          notify_classes = "resource, software, delay, 2bounce, bounce";
+        };
       };
 
     networking.firewall.allowedTCPPorts = [ 25 ];


### PR DESCRIPTION
Followup on #787 

This fixes the format of `settings.main`