### PR TITLE
Rename `unprocessable_entity` to `unprocessable_content`

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -23,7 +23,7 @@ class PasswordsController < ApplicationController
       flash[:success] = t '.success'
       redirect_to new_session_path
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,7 +15,7 @@ class SessionsController < ApplicationController
 
       redirect_to after_sign_in_path
     else
-      render 'new', status: :unprocessable_entity
+      render 'new', status: :unprocessable_content
     end
   end
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -23,7 +23,7 @@ class SubscriptionsController < ApplicationController
       flash[:success] = t '.success'
       redirect_to @subscription
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -38,7 +38,7 @@ class SubscriptionsController < ApplicationController
       flash[:success] = t '.success'
       redirect_to @subscription
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
       flash[:success] = t '.success'
       redirect_to edit_user_path
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -76,7 +76,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
       patch password_url, params: { token:, password: { password: 'a' * 12, password_confirmation: 'b' * 12 } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should return edit if user tries to skip confirmation' do
@@ -86,6 +86,6 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
       patch password_url, params: { token:, password: { password: 'a' * 12 } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -54,13 +54,13 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   test 'should return new if email could not be found' do
     post session_url, params: { session: { email: 'example2@example.org', password: 'password1234' } }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should return new if password was not correct' do
     post session_url, params: { session: { email: 'example@example.org', password: 'password12345' } }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should remove user id and cookie from sessions on sign out' do

--- a/test/controllers/subscriptions_controller_test.rb
+++ b/test/controllers/subscriptions_controller_test.rb
@@ -49,7 +49,7 @@ class SubscriptionsControllerTest < ActionDispatch::IntegrationTest
       post subscriptions_url, params: { subscription: { name: 'My blog', subscribable_type: nil } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   # Show
@@ -94,7 +94,7 @@ class SubscriptionsControllerTest < ActionDispatch::IntegrationTest
       patch subscription_url(@subscription), params: { subscription: { name: nil } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   # Mark all as read

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -39,7 +39,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
                               password_challenge: 'password1234' } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should return edit if user did not include confirmation' do
@@ -47,7 +47,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       patch user_url, params: { user: { password: 'password5678', password_challenge: 'password1234' } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should return edit if user did not include password challenge' do
@@ -55,6 +55,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       patch user_url, params: { user: { password: 'password5678', password_confirmation: 'password5678' } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 end


### PR DESCRIPTION
This renames the deprecated `:unprocessable_entity` with the correct name