### PR TITLE
Show reading progress on entry page

### DIFF
--- a/app/assets/components/entry_reader_element.js
+++ b/app/assets/components/entry_reader_element.js
@@ -1,8 +1,8 @@
 import { SprinklesElement } from "sprinkles-js";
 import { throttle } from "../helpers/throttle";
 
-export class ResizeIframeElement extends SprinklesElement {
-  static tagName = "resize-iframe";
+export class EntryReaderElement extends SprinklesElement {
+  static tagName = "entry-reader";
   static refs = ["iframe", "progress"];
   static events = {
     resize: { method: "updateHeight", element: window },

--- a/app/assets/components/entry_reader_element.js
+++ b/app/assets/components/entry_reader_element.js
@@ -33,11 +33,10 @@ export class EntryReaderElement extends SprinklesElement {
     if (Number.isNaN(progress)) progress = 1;
 
     const clammedProgress = Math.min(1, Math.max(0, progress));
-    const asPercentage = `${Math.round(clammedProgress * 100)}%`;
 
     this.refs.progress.toggleAttribute("data-fits-page", target <= 0);
     this.refs.progress.value = clammedProgress;
-    this.refs.progress.style.setProperty("--progress", asPercentage);
-    this.refs.progress.innerText = asPercentage;
+    this.refs.progress.style.setProperty("--progress", clammedProgress);
+    this.refs.progress.innerText = `${Math.round(clammedProgress * 100)}%`;
   }
 }

--- a/app/assets/entrypoints/application.js
+++ b/app/assets/entrypoints/application.js
@@ -1,5 +1,5 @@
 import "../styles/application.css";
 import "@hotwired/turbo-rails";
-import { ResizeIframeElement } from "../components/resize_iframe";
+import { EntryReaderElement } from "../components/entry_reader_element";
 
-ResizeIframeElement.register();
+EntryReaderElement.register();

--- a/app/assets/helpers/throttle.js
+++ b/app/assets/helpers/throttle.js
@@ -1,0 +1,39 @@
+export function throttle(callback, wait) {
+  let timeout, context, args;
+  let previous = 0;
+
+  const later = () => {
+    previous = Date.now();
+    timeout = null;
+    callback.apply(context, args);
+    context = null;
+    args = null;
+  };
+
+  const throttled = () => {
+    const now = Date.now();
+    const remaining = wait - (now - previous);
+    context = this;
+    args = arguments;
+    if (remaining <= 0 || remaining > wait) {
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = null;
+      }
+      previous = now;
+      callback.apply(context, args);
+    } else if (!timeout) {
+      timeout = setTimeout(later, remaining);
+    }
+  };
+
+  throttled.cancel = () => {
+    clearTimeout(timeout);
+    previous = 0;
+    timeout = null;
+    context = null;
+    args = null;
+  };
+
+  return throttled;
+}

--- a/app/assets/styles/base/theme.css
+++ b/app/assets/styles/base/theme.css
@@ -29,6 +29,9 @@
   --color-white: oklch(100% 0 0deg);
   --color-black: oklch(24.42% 0.006 0.59deg);
 
+  /* Our primary color is color indigo-6 from open-color: https://yeun.github.io/open-color/ */
+  --color-primary: oklch(58.96% 0.2054 268.62deg);
+
   /* Border radius */
   --rounded: 1rem;
   --rounded-full: 9999px;

--- a/app/assets/styles/components/entries.css
+++ b/app/assets/styles/components/entries.css
@@ -16,13 +16,7 @@
 
 .entry__progress {
   --background-color: transparent;
-
-  /* --value-color: var(--color-primary); */
-  --value-color: color-mix(
-    in oklch shorter hue,
-    var(--color-primary) var(--progress, 0),
-    transparent
-  );
+  --value-color: var(--color-primary);
 
   position: fixed;
   inset-block-start: 0;
@@ -32,6 +26,7 @@
   border: none;
   border-radius: 0;
   background-color: transparent;
+  opacity: var(--progress);
 
   &::-moz-progress-bar {
     background-color: var(--value-color);

--- a/app/assets/styles/components/entries.css
+++ b/app/assets/styles/components/entries.css
@@ -14,6 +14,43 @@
   width: 100%;
 }
 
+.entry__progress {
+  --background-color: transparent;
+
+  /* --value-color: var(--color-primary); */
+  --value-color: color-mix(
+    in oklch shorter hue,
+    var(--color-primary) var(--progress, 0),
+    transparent
+  );
+
+  position: fixed;
+  inset-block-start: 0;
+  inset-inline-start: 0;
+  width: 100vw;
+  height: 0.25rem;
+  border: none;
+  border-radius: 0;
+  background-color: transparent;
+
+  &::-moz-progress-bar {
+    background-color: var(--value-color);
+  }
+
+  &::-webkit-progress-bar {
+    background-color: var(--background-color);
+  }
+
+  &::-webkit-progress-value {
+    background-color: var(--value-color);
+  }
+
+  /* If the whole page fits in the viewport, we hide the progress element */
+  &[data-fits-page] {
+    display: none;
+  }
+}
+
 .entry__iframe {
   width: 100%;
   max-width: 48rem;

--- a/app/assets/styles/components/entries.css
+++ b/app/assets/styles/components/entries.css
@@ -26,7 +26,7 @@
   border: none;
   border-radius: 0;
   background-color: transparent;
-  opacity: var(--progress);
+  opacity: calc(var(--progress, 0) / 2 + 0.5);
 
   &::-moz-progress-bar {
     background-color: var(--value-color);

--- a/app/components/entry_component.html.erb
+++ b/app/components/entry_component.html.erb
@@ -6,6 +6,8 @@
   <% end %>
   <% if content? %>
     <resize-iframe class="entry__content">
+      <%# We hide the progress indicator for SR %>
+      <%= tag.progress '0%', value: 0, class: 'entry__progress', data: { resize_iframe_ref: :progress }, aria: { label: t('.reading_progress') } %>
       <%= content_tag :iframe, '', sandbox: 'allow-same-origin allow-top-navigation allow-top-navigation-by-user-activation', srcdoc: transformed_content, class: 'entry__iframe', height: '500px', data: { resize_iframe_ref: 'iframe' } %>
     </resize-iframe>
   <% end %>

--- a/app/components/entry_component.html.erb
+++ b/app/components/entry_component.html.erb
@@ -5,11 +5,10 @@
     <%= content_tag :span, helpers.l(published_at), class: 'entry__published-at' %>
   <% end %>
   <% if content? %>
-    <resize-iframe class="entry__content">
-      <%# We hide the progress indicator for SR %>
-      <%= tag.progress '0%', value: 0, class: 'entry__progress', data: { resize_iframe_ref: :progress }, aria: { label: t('.reading_progress') } %>
-      <%= content_tag :iframe, '', sandbox: 'allow-same-origin allow-top-navigation allow-top-navigation-by-user-activation', srcdoc: transformed_content, class: 'entry__iframe', height: '500px', data: { resize_iframe_ref: 'iframe' } %>
-    </resize-iframe>
+    <entry-reader class="entry__content">
+      <%= tag.progress '0%', value: 0, class: 'entry__progress', data: { entry_reader_ref: :progress }, aria: { label: t('.reading_progress') } %>
+      <%= content_tag :iframe, '', sandbox: 'allow-same-origin allow-top-navigation allow-top-navigation-by-user-activation', srcdoc: transformed_content, class: 'entry__iframe', height: '500px', data: { entry_reader_ref: 'iframe' } %>
+    </entry-reader>
   <% end %>
   <%- if url.present? %>
     <%= link_to t('.go_to_original'), url, class: 'entry__link', target: '_blank', rel: 'noopener noreferrer' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,6 +27,8 @@ en:
       next: "Next"
       previous: "Previous"
       nav_pagination_label: "Entry pagination"
+  entry_component:
+    reading_progress: "Reading progress"
   subscriptions:
     form:
       category_hint: "You can nest categories using `>`. For example: `Music > Bands`"


### PR DESCRIPTION
This adds a progress bar at the top of the viewport, while the user is reading an entry. (If the whole page fits in the viewport, we don't bother with this element).
