### PR TITLE
Show last page instead of erroring when going past page limit

### DIFF
--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require 'pagy/extras/overflow'
+
+Pagy::DEFAULT[:overflow] = :last_page


### PR DESCRIPTION
I routinely ran into this when reading on one device and then refreshing on another.