### PR TITLE
Prevent loop in entry search when entries have the exact same `published_at`

### DIFF
--- a/app/models/entry_search.rb
+++ b/app/models/entry_search.rb
@@ -13,15 +13,19 @@ class EntrySearch
 
   def apply(entry_scope)
     scopes.inject(entry_scope) { |entries, scope| entries.send(*scope) }
-          .order(published_at: :desc, id: :asc)
+          .order(published_at: :desc, id: :desc)
   end
 
   def next(entry_scope, current)
-    apply(entry_scope).where.not(id: current.id).find_by(published_at: ..current.published_at)
+    apply(entry_scope).where.not(id: current.id)
+                      .find_by('published_at < :published_at OR (published_at = :published_at AND id < :id)',
+                               { published_at: current.published_at, id: current.id })
   end
 
   def previous(entry_scope, current)
-    apply(entry_scope).reverse_order.where.not(id: current.id).find_by(published_at: current.published_at..)
+    apply(entry_scope).reverse_order.where.not(id: current.id)
+                      .find_by('published_at > :published_at OR (published_at = :published_at AND id > :id)',
+                               { published_at: current.published_at, id: current.id })
   end
 
   def to_hash

--- a/test/models/entry_search_test.rb
+++ b/test/models/entry_search_test.rb
@@ -46,6 +46,32 @@ class EntrySearchTest < ActiveSupport::TestCase
     assert_equal next_entry, search.next(Entry, current)
   end
 
+  test 'should handle duplicate timestamps when getting previous entry' do
+    previous = create(:entry, published_at: DateTime.current)
+    duplicate = create(:entry, published_at: 2.minutes.ago)
+    current = create(:entry, published_at: duplicate.published_at) # This value needs to be exactly the same
+    next_entry = create(:entry, published_at: 4.minutes.ago)
+
+    search = EntrySearch.new
+
+    assert_equal duplicate, search.previous(Entry, next_entry)
+    assert_equal current, search.previous(Entry, duplicate)
+    assert_equal previous, search.previous(Entry, current)
+  end
+
+  test 'should handle duplicate timestamps when getting next entry' do
+    previous = create(:entry, published_at: DateTime.current)
+    duplicate = create(:entry, published_at: 2.minutes.ago)
+    current = create(:entry, published_at: duplicate.published_at) # This value needs to be exactly the same
+    next_entry = create(:entry, published_at: 4.minutes.ago)
+
+    search = EntrySearch.new
+
+    assert_equal current, search.next(Entry, previous)
+    assert_equal duplicate, search.next(Entry, current)
+    assert_equal next_entry, search.next(Entry, duplicate)
+  end
+
   test 'should respect filter when getting next and previous entry' do
     create(:entry, :read, published_at: 3.minutes.ago)
     create(:entry, :read, published_at: 1.minute.ago)


### PR DESCRIPTION
Fixes #820 

When searching for the next/previous entry, we now also look at the id if published at is the exact same value.