### PR TITLE
Capture timeouts while opening TCP connection

### DIFF
--- a/app/jobs/fetch_proxied_image_job.rb
+++ b/app/jobs/fetch_proxied_image_job.rb
@@ -4,7 +4,9 @@ class FetchProxiedImageJob < ApplicationJob
   queue_as :default
 
   # Retry when we can't open a connection or get a server error
-  retry_on Errno::EBUSY, Net::HTTPFatalError, Socket::ResolutionError, wait: :polynomially_longer, attempts: 10
+  retry_on Errno::EBUSY, Net::HTTPFatalError, Socket::ResolutionError, Net::OpenTimeout, Net::ReadTimeout,
+           OpenSSL::SSL::SSLError,
+           wait: :polynomially_longer, attempts: 10
 
   # Ignore any client errors, as we can't fix these issues
   discard_on Net::HTTPClientException

--- a/app/models/rss_feed.rb
+++ b/app/models/rss_feed.rb
@@ -37,7 +37,8 @@ class RssFeed < ApplicationRecord
       self.error = I18n.t('rss_feeds.errors.too_many_redirects')
     rescue Feedjira::NoParserAvailable
       self.error = I18n.t('rss_feeds.errors.invalid_feed')
-    rescue Net::HTTPClientException, Errno::EBUSY, Errno::ENETUNREACH, Net::HTTPFatalError, Socket::ResolutionError => e
+    rescue Net::HTTPClientException, Errno::EBUSY, Errno::ENETUNREACH, Net::HTTPFatalError, Socket::ResolutionError,
+           Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError => e
       self.error = e.message
     end
 


### PR DESCRIPTION
This handles a few cases where jobs would fail because of various errors while connecting with/reading from remote locations