### PR TITLE
Update entry body styles

### DIFF
--- a/app/assets/entrypoints/entry-body.css
+++ b/app/assets/entrypoints/entry-body.css
@@ -32,3 +32,7 @@
 :where(p) {
   max-width: 72ch; /* Set a reasonable character width */
 }
+
+:where(sup) {
+  line-height: 1; /* Prevent sup from increasing the line height for that specific line */
+}

--- a/app/assets/entrypoints/entry-body.css
+++ b/app/assets/entrypoints/entry-body.css
@@ -16,7 +16,7 @@
 :where(body) {
   margin: 0;
   font-size: 1.125em; /* Bump font size for better readability  */
-  line-height: 1.3; /* Slightly higher line height  */
+  line-height: 1.4; /* Slightly higher line height  */
 }
 
 :where(img, video) {

--- a/app/assets/entrypoints/entry-body.css
+++ b/app/assets/entrypoints/entry-body.css
@@ -10,7 +10,7 @@
 :where(html) {
   font-family: system-ui, sans-serif; /* Use sane fonts by default  */
   overflow-wrap: break-word; /* Make sure we wrap words when needed */
-  overflow: hidden; /* Prevent scrolling inside body  */
+  overflow: scroll hidden; /* Only allow horizontal scroll in body */
 }
 
 :where(body) {


### PR DESCRIPTION
This fixes a few small things to entry bodies:
* We now allow horizontal scrolls. This fixes an issue with some emails that hardcode specific widths
* Increases the default line height for better readability
* Sets the lineheight of `sup` to 1, so that those lines aren't higher than the other in the paragraph