### PR TITLE
Make sure we can follow anchors inside iframe

### DIFF
--- a/app/assets/components/entry_reader_element.js
+++ b/app/assets/components/entry_reader_element.js
@@ -8,12 +8,14 @@ export class EntryReaderElement extends SprinklesElement {
     resize: { method: "updateHeight", element: window },
     load: { method: "updateHeight", ref: "iframe" },
     scroll: { method: "throttledProgress", element: document },
+    hashchange: { method: "scrollToAnchor", element: window },
   };
 
   throttledProgress = throttle(this.#updateProgress.bind(this), 20);
 
   afterConnected() {
     window.requestAnimationFrame(this.updateHeight.bind(this));
+    window.requestAnimationFrame(this.scrollToAnchor.bind(this));
   }
 
   updateHeight() {
@@ -22,6 +24,18 @@ export class EntryReaderElement extends SprinklesElement {
     this.refs.iframe.height = `${height || 500}px`;
 
     this.throttledProgress();
+  }
+
+  scrollToAnchor() {
+    const anchor = window.location.hash;
+    if (anchor === undefined) return;
+
+    const element = this.refs.iframe.contentDocument.querySelector(anchor);
+    if (element === null) return;
+
+    const { y: iframeTop } = this.refs.iframe.getBoundingClientRect();
+    const { y: elementTop } = element.getBoundingClientRect();
+    window.scrollBy(0, iframeTop + elementTop - 16);
   }
 
   #updateProgress() {

--- a/app/assets/styles/base/index.css
+++ b/app/assets/styles/base/index.css
@@ -14,3 +14,10 @@ html {
     color: var(--color-white);
   }
 }
+
+/* Turn on smooth scrolling for users without reduced motion */
+@media (--motion-ok) {
+  * {
+    scroll-behavior: smooth;
+  }
+}


### PR DESCRIPTION
Since we add `<base target="_parent">` to the head of an entry, following anchors inside the iframe doesn't work anymore (note that it also doesn't work in firefox without this). 

We now listen for `hashchange` and then manually scroll to the element inside the entry.