### PR TITLE
Remove `enable_starttls` from SMTP config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,7 +73,6 @@ Rails.application.configure do
     user_name: ENV.fetch('RAILS_SMTP_USER_NAME'),
     password: ENV.fetch('RAILS_SMTP_PASSWORD'),
     authentication: 'login',
-    enable_starttls_auto: true,
     tls: true
   }
 


### PR DESCRIPTION
Fixes [FEED-READER-29](https://robbe-van-petegem.sentry.io/issues/7422890159/events/101d245415104bc195885ff11d82d61e/)

This setting is not compatible with `tls: true`