### PR TITLE
Don't save ingress check if we can't send the mail

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :test do
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'minitest', '~> 5.27' # Pin minitest to 6.x until we update to rails >= 8.1.2
+  gem 'mocha'
   gem 'pundit_assertions'
   gem 'selenium-webdriver'
   gem 'simplecov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,8 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (5.27.0)
+    mocha (3.1.0)
+      ruby2_keywords (>= 0.0.5)
     msgpack (1.8.0)
     mutex_m (0.3.0)
     net-imap (0.6.3)
@@ -322,6 +324,7 @@ GEM
     ruby-vips (2.2.3)
       ffi (~> 1.12)
       logger
+    ruby2_keywords (0.0.5)
     rubyzip (3.2.2)
     sax-machine (1.3.2)
     securerandom (0.4.1)
@@ -413,6 +416,7 @@ DEPENDENCIES
   image_processing
   inline_svg
   minitest (~> 5.27)
+  mocha
   pagy
   pg
   pgreset
@@ -502,6 +506,7 @@ CHECKSUMS
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
+  mocha (3.1.0) sha256=75f42d69ebfb1f10b32489dff8f8431d37a418120ecdfc07afe3bc183d4e1d56
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
   mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
   net-imap (0.6.3) sha256=9bab75f876596d09ee7bf911a291da478e0cd6badc54dfb82874855ccc82f2ad
@@ -551,6 +556,7 @@ CHECKSUMS
   ruby-lsp-rails (0.4.8) sha256=f09d1f926d4063deeb2f3049311925c20dfe6c912371e3bcd04a265a865c44ae
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby-vips (2.2.3) sha256=41d12b1a805cd6ead4a7965201a8f7c5fe459bb58d3a7d967c9eb0719a6edc92
+  ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
   rubyzip (3.2.2) sha256=c0ed99385f0625415c8f05bcae33fe649ed2952894a95ff8b08f26ca57ea5b3c
   sax-machine (1.3.2) sha256=a1112678039eea4c402827ca0d377744e0f882fd6386f29f7b0023d938750d3a
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1

--- a/app/jobs/run_ingress_check_job.rb
+++ b/app/jobs/run_ingress_check_job.rb
@@ -20,8 +20,11 @@ class RunIngressCheckJob < ApplicationJob
   def send_new_ingress_check!
     return if IngressCheck.exists?(created_at: SEND_EVERY.ago..)
 
-    check = IngressCheck.create!
-    SystemMailer.ingress_check(check).deliver_now
+    # If we can't send the mail, we don't want to save the check
+    ActiveRecord::Base.transaction do
+      check = IngressCheck.create!
+      SystemMailer.ingress_check(check).deliver_now
+    end
   end
 
   def check_undelivered_checks

--- a/gemset.nix
+++ b/gemset.nix
@@ -840,6 +840,19 @@
     targets = [];
     version = "5.27.0";
   };
+  mocha = {
+    dependencies = ["ruby2_keywords"];
+    groups = ["test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0mhx9qyiig73mw3zrk8f28ca8dqx8gwgipw94jri07zvxdljvx3m";
+      target = "ruby";
+      type = "gem";
+    };
+    targets = [];
+    version = "3.1.0";
+  };
   msgpack = {
     groups = ["default"];
     platforms = [];
@@ -1508,6 +1521,18 @@
     };
     targets = [];
     version = "2.2.3";
+  };
+  ruby2_keywords = {
+    groups = ["default" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vz322p8n39hz3b4a9gkmz9y7a5jaz41zrm2ywf31dvkqm03glgz";
+      target = "ruby";
+      type = "gem";
+    };
+    targets = [];
+    version = "0.0.5";
   };
   rubyzip = {
     groups = ["default" "test"];

--- a/test/jobs/run_ingress_check_job_test.rb
+++ b/test/jobs/run_ingress_check_job_test.rb
@@ -19,6 +19,16 @@ class RunIngressCheckJobTest < ActiveJob::TestCase
     end
   end
 
+  test 'should not create ingress check if mail can not be send' do
+    SystemMailer.expects(:ingress_check).raises(ArgumentError, 'Some error')
+
+    assert_no_difference 'IngressCheck.count' do
+      assert_raises ArgumentError do
+        RunIngressCheckJob.perform_now
+      end
+    end
+  end
+
   test 'should destroy checks that are more than 10 days old' do
     travel_to((10.days + 1.hour).ago) { create(:ingress_check, :received) }
     travel_to(9.days.ago) { create(:ingress_check, :received) }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,7 @@ end
 require_relative '../config/environment'
 require 'rails/test_help'
 require 'faker'
+require 'mocha/minitest'
 require 'webmock/minitest'
 
 module ValidationAssertions


### PR DESCRIPTION
An issue with sending the mails will bubble up and should be fixed on its own. We don't want to save the ingress check to prevent checks failing due to an issue with sending rather than receiving.