### PR TITLE
Upgrade rails to 8.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'bcrypt' # Use Active Model has_secure_password
 gem 'bootsnap', require: false # Reduces boot times through caching; required in config/boot.rb
 gem 'feedjira' # Parse RSS feeds
 gem 'good_job' # Multithreaded, Postgres-based, ActiveJob backend for Ruby on Rails
-gem 'image_processing', require: 'image_processing/vips' # Use Active Storage variants
+gem 'image_processing' # Use Active Storage variants
 gem 'inline_svg' # Render inline SVGs
 gem 'pagy' # Use pagy for pagination
 gem 'pg' # Use postgresql as the database for Active Record

--- a/Gemfile
+++ b/Gemfile
@@ -5,14 +5,14 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '~> 3.4.5'
 
-gem 'rails', '~> 8.0.5' # We need to pin rails to 8.0.x, since 8.1.x breaks our postfix ingress
+gem 'rails', '~> 8.1'
 
 gem 'addressable' # More standards-compliant URI parser
 gem 'bcrypt' # Use Active Model has_secure_password
 gem 'bootsnap', require: false # Reduces boot times through caching; required in config/boot.rb
 gem 'feedjira' # Parse RSS feeds
 gem 'good_job' # Multithreaded, Postgres-based, ActiveJob backend for Ruby on Rails
-gem 'image_processing' # Use Active Storage variants
+gem 'image_processing', require: 'image_processing/vips' # Use Active Storage variants
 gem 'inline_svg' # Render inline SVGs
 gem 'pagy' # Use pagy for pagination
 gem 'pg' # Use postgresql as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,31 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (8.0.5)
-      actionpack (= 8.0.5)
-      activesupport (= 8.0.5)
+    action_text-trix (2.1.18)
+      railties
+    actioncable (8.1.3)
+      actionpack (= 8.1.3)
+      activesupport (= 8.1.3)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
       zeitwerk (~> 2.6)
-    actionmailbox (8.0.5)
-      actionpack (= 8.0.5)
-      activejob (= 8.0.5)
-      activerecord (= 8.0.5)
-      activestorage (= 8.0.5)
-      activesupport (= 8.0.5)
+    actionmailbox (8.1.3)
+      actionpack (= 8.1.3)
+      activejob (= 8.1.3)
+      activerecord (= 8.1.3)
+      activestorage (= 8.1.3)
+      activesupport (= 8.1.3)
       mail (>= 2.8.0)
-    actionmailer (8.0.5)
-      actionpack (= 8.0.5)
-      actionview (= 8.0.5)
-      activejob (= 8.0.5)
-      activesupport (= 8.0.5)
+    actionmailer (8.1.3)
+      actionpack (= 8.1.3)
+      actionview (= 8.1.3)
+      activejob (= 8.1.3)
+      activesupport (= 8.1.3)
       mail (>= 2.8.0)
       rails-dom-testing (~> 2.2)
-    actionpack (8.0.5)
-      actionview (= 8.0.5)
-      activesupport (= 8.0.5)
+    actionpack (8.1.3)
+      actionview (= 8.1.3)
+      activesupport (= 8.1.3)
       nokogiri (>= 1.8.5)
       rack (>= 2.2.4)
       rack-session (>= 1.0.1)
@@ -31,42 +33,43 @@ GEM
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
       useragent (~> 0.16)
-    actiontext (8.0.5)
-      actionpack (= 8.0.5)
-      activerecord (= 8.0.5)
-      activestorage (= 8.0.5)
-      activesupport (= 8.0.5)
+    actiontext (8.1.3)
+      action_text-trix (~> 2.1.15)
+      actionpack (= 8.1.3)
+      activerecord (= 8.1.3)
+      activestorage (= 8.1.3)
+      activesupport (= 8.1.3)
       globalid (>= 0.6.0)
       nokogiri (>= 1.8.5)
-    actionview (8.0.5)
-      activesupport (= 8.0.5)
+    actionview (8.1.3)
+      activesupport (= 8.1.3)
       builder (~> 3.1)
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activejob (8.0.5)
-      activesupport (= 8.0.5)
+    activejob (8.1.3)
+      activesupport (= 8.1.3)
       globalid (>= 0.3.6)
-    activemodel (8.0.5)
-      activesupport (= 8.0.5)
-    activerecord (8.0.5)
-      activemodel (= 8.0.5)
-      activesupport (= 8.0.5)
+    activemodel (8.1.3)
+      activesupport (= 8.1.3)
+    activerecord (8.1.3)
+      activemodel (= 8.1.3)
+      activesupport (= 8.1.3)
       timeout (>= 0.4.0)
-    activestorage (8.0.5)
-      actionpack (= 8.0.5)
-      activejob (= 8.0.5)
-      activerecord (= 8.0.5)
-      activesupport (= 8.0.5)
+    activestorage (8.1.3)
+      actionpack (= 8.1.3)
+      activejob (= 8.1.3)
+      activerecord (= 8.1.3)
+      activesupport (= 8.1.3)
       marcel (~> 1.0)
-    activesupport (8.0.5)
+    activesupport (8.1.3)
       base64
-      benchmark (>= 0.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      json
       logger (>= 1.4.2)
       minitest (>= 5.1)
       securerandom (>= 0.3)
@@ -242,20 +245,20 @@ GEM
       rack (>= 1.3)
     rackup (2.3.1)
       rack (>= 3)
-    rails (8.0.5)
-      actioncable (= 8.0.5)
-      actionmailbox (= 8.0.5)
-      actionmailer (= 8.0.5)
-      actionpack (= 8.0.5)
-      actiontext (= 8.0.5)
-      actionview (= 8.0.5)
-      activejob (= 8.0.5)
-      activemodel (= 8.0.5)
-      activerecord (= 8.0.5)
-      activestorage (= 8.0.5)
-      activesupport (= 8.0.5)
+    rails (8.1.3)
+      actioncable (= 8.1.3)
+      actionmailbox (= 8.1.3)
+      actionmailer (= 8.1.3)
+      actionpack (= 8.1.3)
+      actiontext (= 8.1.3)
+      actionview (= 8.1.3)
+      activejob (= 8.1.3)
+      activemodel (= 8.1.3)
+      activerecord (= 8.1.3)
+      activestorage (= 8.1.3)
+      activesupport (= 8.1.3)
       bundler (>= 1.15.0)
-      railties (= 8.0.5)
+      railties (= 8.1.3)
     rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
@@ -263,9 +266,9 @@ GEM
     rails-html-sanitizer (1.7.0)
       loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
-    railties (8.0.5)
-      actionpack (= 8.0.5)
-      activesupport (= 8.0.5)
+    railties (8.1.3)
+      actionpack (= 8.1.3)
+      activesupport (= 8.1.3)
       irb (~> 1.13)
       rackup (>= 1.0.0)
       rake (>= 12.2)
@@ -424,7 +427,7 @@ DEPENDENCIES
   pundit
   pundit_assertions
   rack-mini-profiler
-  rails (~> 8.0.5)
+  rails (~> 8.1)
   rubocop
   rubocop-minitest
   rubocop-performance
@@ -443,17 +446,18 @@ DEPENDENCIES
   webmock
 
 CHECKSUMS
-  actioncable (8.0.5) sha256=01a1d1a48b63b1a643fae6b7b4eb2859af55f507b335fca9ab869a5c6742bb8b
-  actionmailbox (8.0.5) sha256=2651a87c0cc3dd1243a3afe64c052e71138f99006b3a5d3fa519198735500054
-  actionmailer (8.0.5) sha256=7918fac842cfe985ed21692f3d212c914a0c816e30e6fa68633177bb22f38561
-  actionpack (8.0.5) sha256=c9de868975dd124a0956499140bd5e63c367865deca01292df7c3195c8da4b35
-  actiontext (8.0.5) sha256=12f3ce3d6326230728316ba14eeac27b2100d6e7d9bfcb4b01fb27b187a812e1
-  actionview (8.0.5) sha256=6d0fa9e63df0cf2729b1f54d0988336c149eb2bbc6049f4c2834d7b62f351413
-  activejob (8.0.5) sha256=2dabe5c3bfe284aba4687c52b930564335435dde3a60b047821f9d3bd0d2ea10
-  activemodel (8.0.5) sha256=c796813d46dc1373f4c6c0ec91dfc520b53683ea773c3b3f9a12c4b3eb145bc2
-  activerecord (8.0.5) sha256=89b261b6cd910c9431cf2475f3f6e5e2f5ce589805043a33ef2b004376a129e6
-  activestorage (8.0.5) sha256=25898a3f8f8aced15ea6a8578cb56955acf3a96ad931e000b2e77e9c8db43df3
-  activesupport (8.0.5) sha256=37f213ff6a37cf3fadfa1a28c1a9678e2cb73b59bb9ebd0eeeca653cccadcb23
+  action_text-trix (2.1.18) sha256=3fdb83f8bff4145d098be283cdd47ac41caf5110bfa6df4695ed7127d7fb3642
+  actioncable (8.1.3) sha256=e5bc7f75e44e6a22de29c4f43176927c3a9ce4824464b74ed18d8226e75a80f0
+  actionmailbox (8.1.3) sha256=df7da474eaa0e70df4ed5a6fef66eb3b3b0f2dbf7f14518deee8d77f1b4aae59
+  actionmailer (8.1.3) sha256=831f724891bb70d0aaa4d76581a6321124b6a752cb655c9346aae5479318448d
+  actionpack (8.1.3) sha256=af998cae4d47c5d581a2cc363b5c77eb718b7c4b45748d81b1887b25621c29a3
+  actiontext (8.1.3) sha256=d291019c00e1ea9e6463011fa214f6081a56d7b9a1d224e7d3f6384c1dafc7d2
+  actionview (8.1.3) sha256=1347c88c7f3edb38100c5ce0e9fb5e62d7755f3edc1b61cce2eb0b2c6ea2fd5d
+  activejob (8.1.3) sha256=a149b1766aa8204c3c3da7309e4becd40fcd5529c348cffbf6c9b16b565fe8d3
+  activemodel (8.1.3) sha256=90c05cbe4cef3649b8f79f13016191ea94c4525ce4a5c0fb7ef909c4b91c8219
+  activerecord (8.1.3) sha256=8003be7b2466ba0a2a670e603eeb0a61dd66058fccecfc49901e775260ac70ab
+  activestorage (8.1.3) sha256=0564ce9309143951a67615e1bb4e090ee54b8befed417133cae614479b46384d
+  activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   annotaterb (4.22.0) sha256=66fc40e5f48d5b82ae82013da1e5b43aaaad41ee9bd3d0cf803048efc0a70286
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
@@ -536,10 +540,10 @@ CHECKSUMS
   rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
-  rails (8.0.5) sha256=4cb40f90948be292fa15cc7cb37757b97266585145c6e76957464b40edfd5be6
+  rails (8.1.3) sha256=6d017ba5348c98fc909753a8169b21d44de14d2a0b92d140d1a966834c3c9cd3
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
   rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
-  railties (8.0.5) sha256=ad98c6e9a096b7e8cf63c70872b60ec6c1d4152be2a4ffa63483ec02a837a9d5
+  railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
   rbs (4.0.2) sha256=af75671e66cd03434cc546622741ebf83f6197ec4328375805306330bf78ef25

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ Bundler.require(*Rails.groups)
 module FeedReader
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 8.0
+    config.load_defaults 8.1
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ module FeedReader
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks])
+    config.autoload_lib(ignore: %w[assets mailbox_relayer tasks])
 
     # Set good job as our queue adapter in all environments
     config.active_job.queue_adapter = :good_job

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,11 +50,6 @@ Rails.application.configure do
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   # config.active_job.queue_adapter = :resque
-  # config.active_job.queue_name_prefix = "feed_reader_production"
-
-  # Disable caching for Action Mailer templates even if Action Controller
-  # caching is enabled.
-  config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/gemset.nix
+++ b/gemset.nix
@@ -1,16 +1,29 @@
 {
+  action_text-trix = {
+    dependencies = ["railties"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0hinzgbjfwgdjm3dz9mz218sy764gbacv0z2ic4ms57lpzw87nrz";
+      target = "ruby";
+      type = "gem";
+    };
+    targets = [];
+    version = "2.1.18";
+  };
   actioncable = {
     dependencies = ["actionpack" "activesupport" "nio4r" "websocket-driver" "zeitwerk"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "12xv89kmr6l6mflzqddk0zsmbbsr53mv9dz6z91sdcb3ifjd3881";
+      sha256 = "1w40bbkjd0lds57bfr24hbj9qfkwj9v33x6457g24sjfwispzg75";
       target = "ruby";
       type = "gem";
     };
     targets = [];
-    version = "8.0.5";
+    version = "8.1.3";
   };
   actionmailbox = {
     dependencies = ["actionpack" "activejob" "activerecord" "activestorage" "activesupport" "mail"];
@@ -18,12 +31,12 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0m00a0sqf68rllzmsfkb02cqy4vi5q2lrrmgld1i5pf31iyahl96";
+      sha256 = "0ndf98dpzmz8xs6m253zpwnhyfrvxdkfyvssxps0vrx0x9sa8zfz";
       target = "ruby";
       type = "gem";
     };
     targets = [];
-    version = "8.0.5";
+    version = "8.1.3";
   };
   actionmailer = {
     dependencies = ["actionpack" "actionview" "activejob" "activesupport" "mail" "rails-dom-testing"];
@@ -31,12 +44,12 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0qc5ycibnxricdlgmrihds0hqjli5hhksbv947nqbsfg8b4gl63r";
+      sha256 = "13a4329lgrda8s9mqrfbaakvc90i6ak82rfpljmd0w5vj54747w3";
       target = "ruby";
       type = "gem";
     };
     targets = [];
-    version = "8.0.5";
+    version = "8.1.3";
   };
   actionpack = {
     dependencies = ["actionview" "activesupport" "nokogiri" "rack" "rack-session" "rack-test" "rails-dom-testing" "rails-html-sanitizer" "useragent"];
@@ -44,25 +57,25 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0dabvb49acbwvy91587cbn36ghv3bsyl14a9aq4ll4nxfn4qdpn9";
+      sha256 = "18r93ii2ayw8n60qsx259dy8nwgbfxf3ndncla0xbia79np8r6dg";
       target = "ruby";
       type = "gem";
     };
     targets = [];
-    version = "8.0.5";
+    version = "8.1.3";
   };
   actiontext = {
-    dependencies = ["actionpack" "activerecord" "activestorage" "activesupport" "globalid" "nokogiri"];
+    dependencies = ["action_text-trix" "actionpack" "activerecord" "activestorage" "activesupport" "globalid" "nokogiri"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1q8jm23v29zv055wpgyrwzb008bvqbm4x8bb64l0f8r6ccywxwqj";
+      sha256 = "1ln7mwflqf7nsgkj9lm1p7bmc6h8yqaa47q1cdj9xsp102f034fj";
       target = "ruby";
       type = "gem";
     };
     targets = [];
-    version = "8.0.5";
+    version = "8.1.3";
   };
   actionview = {
     dependencies = ["activesupport" "builder" "erubi" "rails-dom-testing" "rails-html-sanitizer"];
@@ -70,12 +83,12 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "04ql6lpvdmrl5169y166pfr9w53c6f40jkgmn4ljgkzh7pkaj3vd";
+      sha256 = "0pgxl9p2q2zbwb6626yw7rgpbmv2bvxykq2w1h83inrygy6chiqk";
       target = "ruby";
       type = "gem";
     };
     targets = [];
-    version = "8.0.5";
+    version = "8.1.3";
   };
   activejob = {
     dependencies = ["activesupport" "globalid"];
@@ -83,12 +96,12 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "047asb83p78zh93v0q1svrfl6da3aqqbjlkwd2jap172pz1ybard";
+      sha256 = "1lz8bxb6pcf9yvxwyj6355aws3ylxi5rwc577ly4q858d9vb2jd1";
       target = "ruby";
       type = "gem";
     };
     targets = [];
-    version = "8.0.5";
+    version = "8.1.3";
   };
   activemodel = {
     dependencies = ["activesupport"];
@@ -96,12 +109,12 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1hjv2kmv7i0jk8zkng3pxa1kdd90qpgr3v60qvs764yw8qyq35n7";
+      sha256 = "06c23jww82grgvxw19g4bi9c957aj5hh24wzyyw4jdpg9jz5rh4h";
       target = "ruby";
       type = "gem";
     };
     targets = [];
-    version = "8.0.5";
+    version = "8.1.3";
   };
   activerecord = {
     dependencies = ["activemodel" "activesupport" "timeout"];
@@ -109,12 +122,12 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1ri9l5v4601bxwrkl105k1ccxxg2wpvg6x94rwqr834irnv63cl9";
+      sha256 = "1avhmih54xqyj14zrv6ciw2ndpb11bmkwq0fcwm0mfk64ixvw0w0";
       target = "ruby";
       type = "gem";
     };
     targets = [];
-    version = "8.0.5";
+    version = "8.1.3";
   };
   activestorage = {
     dependencies = ["actionpack" "activejob" "activerecord" "activesupport" "marcel"];
@@ -122,25 +135,25 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1wrxnj6rqzp7n80f0cfrdalz7b2md6sqqmx8lrgd3klaiwzqm295";
+      sha256 = "0k9q8sdlf576r8rp2hgdxy5lpr8f157bpq8mfsk52f8l169wwr05";
       target = "ruby";
       type = "gem";
     };
     targets = [];
-    version = "8.0.5";
+    version = "8.1.3";
   };
   activesupport = {
-    dependencies = ["base64" "benchmark" "bigdecimal" "concurrent-ruby" "connection_pool" "drb" "i18n" "logger" "minitest" "securerandom" "tzinfo" "uri"];
+    dependencies = ["base64" "bigdecimal" "concurrent-ruby" "connection_pool" "drb" "i18n" "json" "logger" "minitest" "securerandom" "tzinfo" "uri"];
     groups = ["default" "development" "production" "test"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "08ybmp63qrfaxq7bv7mvb4xvfb4fcylw2a0szankzkrpdbzi7wip";
+      sha256 = "03m2vjhq3nmc8c3hpivxhvkjd8igg16nmv0p2fgdsgacppgy1991";
       target = "ruby";
       type = "gem";
     };
     targets = [];
-    version = "8.0.5";
+    version = "8.1.3";
   };
   addressable = {
     dependencies = ["public_suffix"];
@@ -1253,12 +1266,12 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1rjvzpnl0js6axlygij5a5c6cwmraxvv6z6c2px95qlbjj80zd2c";
+      sha256 = "1lww7i686rm9s50d34hb596y2kfl46dida2kjy8gr64c6jjpn0bd";
       target = "ruby";
       type = "gem";
     };
     targets = [];
-    version = "8.0.5";
+    version = "8.1.3";
   };
   rails-dom-testing = {
     dependencies = ["activesupport" "minitest" "nokogiri"];
@@ -1292,12 +1305,12 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1md96yl05v436jkgz9725cax9hf61sv74267cg7yidwnl3lwd65d";
+      sha256 = "08nyhsigcvjpj9i3r0s73yi8zm16sxmr2x7xgxlaq2jjrghb0gli";
       target = "ruby";
       type = "gem";
     };
     targets = [];
-    version = "8.0.5";
+    version = "8.1.3";
   };
   rainbow = {
     groups = ["default" "development"];

--- a/lib/mailbox_relayer/ingress.rb
+++ b/lib/mailbox_relayer/ingress.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative 'relayer'
+
+# NOTE: This `main` method in this file does exactly the same as `rails action_mailbox:ingress:postfix`
+# The only changes compared to that rake task are to make this work without relying on rails and linting fixes
+
+def string_blank?(string)
+  !string.is_a?(String) || string.empty?
+end
+
+# rubocop:disable Rails/Exit, Rails/Output
+def main
+  url, password = ENV.values_at('URL', 'INGRESS_PASSWORD')
+
+  if string_blank?(url) || string_blank?(password)
+    print '4.3.5 URL and INGRESS_PASSWORD are required'
+    exit 1
+  end
+
+  MailboxRelayer::Relayer.new(url: url, password: password).relay(STDIN.read).tap do |result|
+    print "#{result.status_code} #{result.message}"
+    exit result.success?
+  end
+end
+# rubocop:enable Rails/Exit, Rails/Output
+
+main

--- a/lib/mailbox_relayer/ingress.rb
+++ b/lib/mailbox_relayer/ingress.rb
@@ -18,7 +18,7 @@ def main
     exit 1
   end
 
-  MailboxRelayer::Relayer.new(url: url, password: password).relay(STDIN.read).tap do |result|
+  MailboxRelayer::Relayer.new(url: url, password: password).relay($stdin.read).tap do |result|
     print "#{result.status_code} #{result.message}"
     exit result.success?
   end

--- a/lib/mailbox_relayer/relayer.rb
+++ b/lib/mailbox_relayer/relayer.rb
@@ -62,7 +62,7 @@ module MailboxRelayer
       client.post uri, source,
                   'Content-Type' => CONTENT_TYPE,
                   'User-Agent' => USER_AGENT,
-                  'Authorization' => "Basic #{Base64.strict_encode64(username + ':' + password)}"
+                  'Authorization' => "Basic #{Base64.strict_encode64("#{username}:#{password}")}"
     end
 
     def client

--- a/lib/mailbox_relayer/relayer.rb
+++ b/lib/mailbox_relayer/relayer.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# NOTE: This file is a copy from https://github.com/rails/rails/blob/main/actionmailbox/lib/action_mailbox/relayer.rb,
+# but slightly reworked so that we don't fully need to load rails to send a post request
+# The only changes in this file are to make the code work outside of rails and linting fixes
+
+require 'base64'
+require 'net/http'
+require 'uri'
+
+module MailboxRelayer
+  class Relayer
+    Result = Struct.new(:status_code, :message) do
+      def success?
+        !failure?
+      end
+
+      def failure?
+        transient_failure? || permanent_failure?
+      end
+
+      def transient_failure?
+        status_code.start_with?('4.')
+      end
+
+      def permanent_failure?
+        status_code.start_with?('5.')
+      end
+    end
+
+    CONTENT_TYPE = 'message/rfc822'
+    USER_AGENT   = 'Action Mailbox relayer'
+
+    attr_reader :uri, :username, :password
+
+    def initialize(url:, password:, username: 'actionmailbox')
+      @uri = URI(url)
+      @username = username
+      @password = password
+    end
+
+    def relay(source)
+      case response = post(source)
+      when Net::HTTPSuccess
+        Result.new '2.0.0', 'Successfully relayed message to ingress'
+      when Net::HTTPUnauthorized
+        Result.new '4.7.0', 'Invalid credentials for ingress'
+      else
+        Result.new '4.0.0', "HTTP #{response.code}"
+      end
+    rescue IOError, SocketError, SystemCallError => e
+      Result.new '4.4.2', "Network error relaying to ingress: #{e.message}"
+    rescue Timeout::Error
+      Result.new '4.4.2', 'Timed out relaying to ingress'
+    rescue StandardError => e
+      Result.new '4.0.0', "Error relaying to ingress: #{e.message}"
+    end
+
+    private
+
+    def post(source)
+      client.post uri, source,
+                  'Content-Type' => CONTENT_TYPE,
+                  'User-Agent' => USER_AGENT,
+                  'Authorization' => "Basic #{Base64.strict_encode64(username + ':' + password)}"
+    end
+
+    def client
+      @client ||= Net::HTTP.new(uri.host, uri.port).tap do |connection|
+        if uri.scheme == 'https'
+          require 'openssl'
+
+          connection.use_ssl     = true
+          connection.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        end
+
+        connection.open_timeout = 1
+        connection.read_timeout = 10
+      end
+    end
+  end
+end

--- a/module.nix
+++ b/module.nix
@@ -56,10 +56,10 @@ let
     ${feed-reader.env}/bin/bundle exec rails "$@"
   '';
   relayMailScript = pkgs.writeShellScript "feed-reader-mail-relay" ''
-    ${exports}
     export $(${pkgs.coreutils}/bin/cat ${cfg.environmentFile} | ${pkgs.findutils}/bin/xargs)
-    cd ${feed-reader}
-    ${feed-reader.env}/bin/bundle exec rails action_mailbox:ingress:postfix URL='https://${cfg.hostname}/rails/action_mailbox/relay/inbound_emails' INGRESS_PASSWORD=$RAILS_INBOUND_EMAIL_PASSWORD
+    export URL='https://${cfg.hostname}/rails/action_mailbox/relay/inbound_emails'
+    export INGRESS_PASSWORD=$RAILS_INBOUND_EMAIL_PASSWORD
+    ${feed-reader.env.wrappedRuby}/bin/ruby ${feed-reader}/lib/mailbox_relayer/ingress.rb
   '';
 in
 {


### PR DESCRIPTION
Fixes #1082 

This PR upgrades rails to v8.1. Since rails now loads ruby-vips on boot (and this doesn't work when postfix executes this command), I added a `MailboxRelayer::Relayer` and an ingress action, so that we can relay mails to action mailbox without needing to load rails