### PR TITLE
Use nix flake in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,42 +13,28 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RAILS_ENV: "test"
-      DATABASE_URL: "postgres://feed_reader:feed_reader@127.0.0.1:5432/feed_reader"
-    services:
-      postgresql:
-        image: postgres
-        env:
-          POSTGRES_DB: feed_reader_test
-          POSTGRES_PASSWORD: "feed_reader"
-          POSTGRES_USER: feed_reader
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
-      - name: Setup ruby from /.ruby_version
-        uses: ruby/setup-ruby@v1
+      - uses: cachix/install-nix-action@v31
         with:
-          bundler-cache: true
-      - name: Set up Node
-        uses: actions/setup-node@v7
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cachix
+        uses: cachix/cachix-action@v17
         with:
-          node-version: "lts/*"
-          cache: "npm"
-      - name: Install libvips
-        run: sudo apt-get update && sudo apt-get install libvips
+          name: feed-reader
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Install dependencies
-        run: npm ci
+        run: nix develop --command npm ci
       - name: Compile assets
-        run: RAILS_ENV=test bundle exec rails assets:precompile
-      - name: Run tests
-        env:
-          CI: true
+        run: nix develop --command nix develop --command rails assets:precompile
+      - name: Setup database
         run: |
-          bundle exec rails db:setup
-          bundle exec rails db:migrate
-          bundle exec rails test
+          nix develop --command pg:start
+          nix develop --command rails db:setup
+          nix develop --command rails db:migrate
+      - name: Run tests
+        run: nix develop --command  rails test
       - name: Report coverage
         uses: codecov/codecov-action@v7
         with:
@@ -58,32 +44,39 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
-      - name: Setup ruby from /.ruby_version
-        uses: ruby/setup-ruby@v1
+      - uses: cachix/install-nix-action@v31
         with:
-          bundler-cache: true
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cachix
+        uses: cachix/cachix-action@v17
+        with:
+          name: feed-reader
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Lint with rubocop
-        run: bundle exec rubocop -c .rubocop.yml
+        run: nix develop --command rubocop -c .rubocop.yml
       - name: Lint with erb_lint
-        run: bundle exec erb_lint --lint-all
+        run: nix develop --command erb_lint --lint-all
       - name: Scan with brakeman
-        run: bundle exec brakeman --no-pager
+        run: nix develop --command brakeman --no-pager
   lint-node:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
-      - name: Set up Node
-        uses: actions/setup-node@v7
+      - uses: cachix/install-nix-action@v31
         with:
-          node-version: "lts/*"
-          cache: "npm"
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cachix
+        uses: cachix/cachix-action@v17
+        with:
+          name: feed-reader
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Install dependencies
-        run: npm ci
+        run: nix develop --command npm ci
       - name: Lint with eslint
-        run: npm run lint:js -- --no-fix --max-warnings 0
+        run: nix develop --command npm run lint:js -- --no-fix --max-warnings 0
       - name: Lint with stylelint
-        run: npm run lint:css -- --max-warnings 0
+        run: nix develop --command npm run lint:css -- --max-warnings 0
   lint-nix:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -91,38 +84,24 @@ jobs:
       - uses: actions/checkout@v7
       - uses: cachix/install-nix-action@v31
         with:
-          nix_path: nixpkgs=channel:nixos-23.05
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Lint with nixpkgs-fmt
-        run: nix-shell -p nixpkgs-fmt --run "nixpkgs-fmt --check flake.nix module.nix"
+        run: nix develop --command nixpkgs-fmt --check flake.nix module.nix
   precompile:
     runs-on: ubuntu-latest
     env:
       RAILS_ENV: "test"
-      DATABASE_URL: "postgres://feed_reader:feed_reader@127.0.0.1:5432/feed_reader"
-    services:
-      postgresql:
-        image: postgres
-        env:
-          POSTGRES_DB: feed_reader_test
-          POSTGRES_PASSWORD: "feed_reader"
-          POSTGRES_USER: feed_reader
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v7
-      - name: Setup ruby from /.ruby_version
-        uses: ruby/setup-ruby@v1
+      - uses: cachix/install-nix-action@v31
         with:
-          bundler-cache: true
-      - name: Set up Node
-        uses: actions/setup-node@v7
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cachix
+        uses: cachix/cachix-action@v17
         with:
-          node-version: "lts/*"
-          cache: "npm"
-      - name: Install libvips
-        run: sudo apt-get update && sudo apt-get install libvips
+          name: feed-reader
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Install dependencies
-        run: npm ci
+        run: nix develop --command npm ci
       - name: Compile assets
-        run: bundle exec rails assets:precompile
+        run: nix develop --command nix develop --command rails assets:precompile

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - uses: cachix/install-nix-action@v31
         with:
-          nix_path: nixpkgs=channel:nixos-23.05
+          nix_path: nixpkgs=channel:nixos-unstable
       - name: Run bundix
         run: nix develop .#deps --command bundix
       - uses: stefanzweifel/git-auto-commit-action@v7.2.0


### PR DESCRIPTION
This updates the CI workflows to use the nix flake, ensuring that we're using the same setup and dependencies when running the CI as we do in development (and in production)